### PR TITLE
Update build_source script to exclude epoch from version

### DIFF
--- a/build_source.py
+++ b/build_source.py
@@ -38,7 +38,7 @@ class Changelog(object):
   def populate(self):
     p = Popen(['dpkg-parsechangelog', '-l' + self.path], stdout=PIPE)
     out = p.communicate()[0]
-    matches = re.search(r"^Source: (.+)\nVersion: ([^-\n]+)", out)
+    matches = re.search(r"^Source: (.+)\nVersion: (?:\d+:)?([^-\n]+)", out)
 
     self.source = matches.group(1)
     self.version = matches.group(2)


### PR DESCRIPTION
If the epoch is included in the version number debbuild fails to find the orig.tar.gz.
