### PR TITLE
Remove rbenv dependency on ruby.

### DIFF
--- a/pkg/rbenv/debian/changelog
+++ b/pkg/rbenv/debian/changelog
@@ -1,3 +1,15 @@
+rbenv (0.4.0-ppa1~lucid3) lucid; urgency=low
+
+  * Remove dependency on ruby
+
+ -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Fri, 22 Nov 2013 11:50:44 +0000
+
+rbenv (0.4.0-ppa1~precise3) precise; urgency=low
+
+  * Remove dependency on ruby
+
+ -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Fri, 22 Nov 2013 11:39:16 +0000
+
 rbenv (0.4.0-ppa1~lucid2) lucid; urgency=low
 
   * Rebuild against Lucid for our PPA.

--- a/pkg/rbenv/debian/control
+++ b/pkg/rbenv/debian/control
@@ -11,7 +11,7 @@ XS-Ruby-Versions: all
 Package: rbenv
 Architecture: all
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${shlibs:Depends}, ${misc:Depends}, ruby | ruby-interpreter
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: simple per-user Ruby version manager
  rbenv lets you easily switch between multiple versions of Ruby. It's
  simple, unobtrusive, and follows the UNIX tradition of single-purpose


### PR DESCRIPTION
rbenv provides various ruby interpreters, but does not itself depend on ruby (it's all bash scripts).

This supersedes #5 (which was fine, but we need to keep the maintainer as one of our team).
