### PR TITLE
Backport libyaml regression fix to lucid

### DIFF
--- a/pkg/libyaml/debian/changelog
+++ b/pkg/libyaml/debian/changelog
@@ -1,6 +1,21 @@
+libyaml (0.1.4-2ubuntu0.10.04.2ppa1) lucid; urgency=low
+
+  * Backport regression fix to lucid
+  * SECURITY REGRESSION: parsing regression in security update
+    (LP: #1279805)
+    - debian/patches/CVE-2013-6393.patch: updated to use upstream commits
+      from 0.1.5.
+
+ -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Mon, 17 Feb 2014 09:33:42 +0000
+
 libyaml (0.1.4-2ubuntu0.10.04.1ppa1) lucid; urgency=medium
 
   * Backport Precise version to lucid
+  * SECURITY UPDATE: denial of service and possible code execution via
+    large yaml documents
+    - debian/patches/CVE-2013-6393.patch: fix integer overflows in
+      src/scanner.c, src/api.c.
+    - CVE-2013-6393
 
  -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Fri, 07 Feb 2014 08:40:39 +0000
 

--- a/pkg/libyaml/debian/patches/CVE-2013-6393.patch
+++ b/pkg/libyaml/debian/patches/CVE-2013-6393.patch
@@ -1,160 +1,155 @@
 Description: fix denial of service and possible code execution via
  large yaml documents
-Author: Florian Weimer <fweimer@redhat.com>, John Eckersberg <jeckersb@redhat.com>
-Origin: vendor, https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+Origin: upstream, https://bitbucket.org/xi/libyaml/commits/1d73f004f49e6962cf936da98aecf0aec95c4c50
+Origin: upstream, https://bitbucket.org/xi/libyaml/commits/b77d42277c32b58a114a0fa0968038a4b0ab24f4
+Origin: upstream, https://bitbucket.org/xi/libyaml/commits/f859ed1eb757a3562b98a28a8ce69274bfd4b3f2
+Origin: upstream, https://bitbucket.org/xi/libyaml/commits/0df2fb962294f3a6df1450a3e08c6a0f74f9078c
+Origin: upstream, https://bitbucket.org/xi/libyaml/commits/af3599437a87162554787c52d8b16eab553f537b
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/libyaml/+bug/1279805
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/libyaml/+bug/1276156
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737076
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=738587
+Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=1033990
 
-Index: libyaml-0.1.4/src/api.c
+Index: libyaml-0.1.4/src/loader.c
 ===================================================================
---- libyaml-0.1.4.orig/src/api.c	2011-05-29 01:55:42.000000000 -0400
-+++ libyaml-0.1.4/src/api.c	2014-01-31 13:04:14.675831124 -0500
-@@ -117,7 +117,12 @@
- YAML_DECLARE(int)
- yaml_stack_extend(void **start, void **top, void **end)
- {
--    void *new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
-+    void *new_start;
-+
-+    if ((char *)*end - (char *)*start >= INT_MAX / 2)
-+	return 0;
-+
-+    new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
+--- libyaml-0.1.4.orig/src/loader.c	2011-05-29 01:55:42.000000000 -0400
++++ libyaml-0.1.4/src/loader.c	2014-02-13 08:32:26.228856720 -0500
+@@ -286,6 +286,8 @@
+     int index;
+     yaml_char_t *tag = first_event->data.scalar.tag;
  
-     if (!new_start) return 0;
++    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
++
+     if (!tag || strcmp((char *)tag, "!") == 0) {
+         yaml_free(tag);
+         tag = yaml_strdup((yaml_char_t *)YAML_DEFAULT_SCALAR_TAG);
+@@ -329,6 +331,8 @@
+     int index, item_index;
+     yaml_char_t *tag = first_event->data.sequence_start.tag;
+ 
++    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
++
+     if (!tag || strcmp((char *)tag, "!") == 0) {
+         yaml_free(tag);
+         tag = yaml_strdup((yaml_char_t *)YAML_DEFAULT_SEQUENCE_TAG);
+@@ -351,6 +355,9 @@
+     if (!yaml_parser_parse(parser, &event)) return 0;
+ 
+     while (event.type != YAML_SEQUENCE_END_EVENT) {
++        if (!STACK_LIMIT(parser,
++                    parser->document->nodes.start[index-1].data.sequence.items,
++                    INT_MAX-1)) return 0;
+         item_index = yaml_parser_load_node(parser, &event);
+         if (!item_index) return 0;
+         if (!PUSH(parser,
+@@ -387,6 +394,8 @@
+     yaml_node_pair_t pair;
+     yaml_char_t *tag = first_event->data.mapping_start.tag;
+ 
++    if (!STACK_LIMIT(parser, parser->document->nodes, INT_MAX-1)) goto error;
++
+     if (!tag || strcmp((char *)tag, "!") == 0) {
+         yaml_free(tag);
+         tag = yaml_strdup((yaml_char_t *)YAML_DEFAULT_MAPPING_TAG);
+@@ -409,6 +418,9 @@
+     if (!yaml_parser_parse(parser, &event)) return 0;
+ 
+     while (event.type != YAML_MAPPING_END_EVENT) {
++        if (!STACK_LIMIT(parser,
++                    parser->document->nodes.start[index-1].data.mapping.pairs,
++                    INT_MAX-1)) return 0;
+         pair.key = yaml_parser_load_node(parser, &event);
+         if (!pair.key) return 0;
+         if (!yaml_parser_parse(parser, &event)) return 0;
+Index: libyaml-0.1.4/src/reader.c
+===================================================================
+--- libyaml-0.1.4.orig/src/reader.c	2011-05-29 01:55:42.000000000 -0400
++++ libyaml-0.1.4/src/reader.c	2014-02-13 08:32:30.716856793 -0500
+@@ -460,6 +460,10 @@
+ 
+     }
+ 
++    if (parser->offset >= PTRDIFF_MAX)
++        return yaml_parser_set_reader_error(parser, "input is too long",
++                PTRDIFF_MAX, -1);
++
+     return 1;
+ }
  
 Index: libyaml-0.1.4/src/scanner.c
 ===================================================================
---- libyaml-0.1.4.orig/src/scanner.c	2011-05-29 01:55:42.000000000 -0400
-+++ libyaml-0.1.4/src/scanner.c	2014-01-31 13:04:18.811831235 -0500
-@@ -615,11 +615,14 @@
+--- libyaml-0.1.4.orig/src/scanner.c	2014-02-13 08:31:50.000000000 -0500
++++ libyaml-0.1.4/src/scanner.c	2014-02-13 08:32:32.836856827 -0500
+@@ -615,11 +615,11 @@
   */
  
  static int
 -yaml_parser_roll_indent(yaml_parser_t *parser, int column,
-+yaml_parser_roll_indent(yaml_parser_t *parser, size_t column,
-         int number, yaml_token_type_t type, yaml_mark_t mark);
+-        int number, yaml_token_type_t type, yaml_mark_t mark);
++yaml_parser_roll_indent(yaml_parser_t *parser, ptrdiff_t column,
++        ptrdiff_t number, yaml_token_type_t type, yaml_mark_t mark);
  
  static int
 -yaml_parser_unroll_indent(yaml_parser_t *parser, int column);
-+yaml_parser_unroll_indent(yaml_parser_t *parser, size_t column);
-+
-+static int
-+yaml_parser_reset_indent(yaml_parser_t *parser);
++yaml_parser_unroll_indent(yaml_parser_t *parser, ptrdiff_t column);
  
  /*
   * Token fetchers.
-@@ -1206,7 +1209,7 @@
+@@ -1103,7 +1103,7 @@
+      */
+ 
+     int required = (!parser->flow_level
+-            && parser->indent == (int)parser->mark.column);
++            && parser->indent == (ptrdiff_t)parser->mark.column);
+ 
+     /*
+      * A simple key is required only when it is the first token in the current
+@@ -1176,6 +1176,11 @@
+ 
+     /* Increase the flow level. */
+ 
++    if (parser->flow_level == INT_MAX) {
++        parser->error = YAML_MEMORY_ERROR;
++        return 0;
++    }
++
+     parser->flow_level++;
+ 
+     return 1;
+@@ -1206,8 +1211,8 @@
   */
  
  static int
 -yaml_parser_roll_indent(yaml_parser_t *parser, int column,
-+yaml_parser_roll_indent(yaml_parser_t *parser, size_t column,
-         int number, yaml_token_type_t type, yaml_mark_t mark)
+-        int number, yaml_token_type_t type, yaml_mark_t mark)
++yaml_parser_roll_indent(yaml_parser_t *parser, ptrdiff_t column,
++        ptrdiff_t number, yaml_token_type_t type, yaml_mark_t mark)
  {
      yaml_token_t token;
-@@ -1216,7 +1219,7 @@
-     if (parser->flow_level)
-         return 1;
  
--    if (parser->indent < column)
-+    if (parser->indent == -1 || parser->indent < column)
-     {
-         /*
-          * Push the current indentation level to the stack and set the new
-@@ -1254,7 +1257,7 @@
+@@ -1226,6 +1231,11 @@
+         if (!PUSH(parser, parser->indents, parser->indent))
+             return 0;
+ 
++        if (column > INT_MAX) {
++            parser->error = YAML_MEMORY_ERROR;
++            return 0;
++        }
++
+         parser->indent = column;
+ 
+         /* Create a token and insert it into the queue. */
+@@ -1254,7 +1264,7 @@
  
  
  static int
 -yaml_parser_unroll_indent(yaml_parser_t *parser, int column)
-+yaml_parser_unroll_indent(yaml_parser_t *parser, size_t column)
++yaml_parser_unroll_indent(yaml_parser_t *parser, ptrdiff_t column)
  {
      yaml_token_t token;
  
-@@ -1263,6 +1266,15 @@
-     if (parser->flow_level)
-         return 1;
- 
-+    /*
-+     * column is unsigned and parser->indent is signed, so if
-+     * parser->indent is less than zero the conditional in the while
-+     * loop below is incorrect.  Guard against that.
-+     */
-+    
-+    if (parser->indent < 0)
-+        return 1;
-+
-     /* Loop through the intendation levels in the stack. */
- 
-     while (parser->indent > column)
-@@ -1283,6 +1295,41 @@
- }
- 
- /*
-+ * Pop indentation levels from the indents stack until the current
-+ * level resets to -1.  For each intendation level, append the
-+ * BLOCK-END token.
-+ */
-+
-+static int
-+yaml_parser_reset_indent(yaml_parser_t *parser)
-+{
-+    yaml_token_t token;
-+
-+    /* In the flow context, do nothing. */
-+
-+    if (parser->flow_level)
-+        return 1;
-+
-+    /* Loop through the intendation levels in the stack. */
-+
-+    while (parser->indent > -1)
-+    {
-+        /* Create a token and append it to the queue. */
-+
-+        TOKEN_INIT(token, YAML_BLOCK_END_TOKEN, parser->mark, parser->mark);
-+
-+        if (!ENQUEUE(parser, parser->tokens, token))
-+            return 0;
-+
-+        /* Pop the indentation level. */
-+
-+        parser->indent = POP(parser, parser->indents);
-+    }
-+
-+    return 1;
-+}
-+
-+/*
-  * Initialize the scanner and produce the STREAM-START token.
-  */
- 
-@@ -1338,7 +1385,7 @@
- 
-     /* Reset the indentation level. */
- 
--    if (!yaml_parser_unroll_indent(parser, -1))
-+    if (!yaml_parser_reset_indent(parser))
-         return 0;
- 
-     /* Reset simple keys. */
-@@ -1369,7 +1416,7 @@
- 
-     /* Reset the indentation level. */
- 
--    if (!yaml_parser_unroll_indent(parser, -1))
-+    if (!yaml_parser_reset_indent(parser))
-         return 0;
- 
-     /* Reset simple keys. */
-@@ -1407,7 +1454,7 @@
- 
-     /* Reset the indentation level. */
- 
--    if (!yaml_parser_unroll_indent(parser, -1))
-+    if (!yaml_parser_reset_indent(parser))
-         return 0;
- 
-     /* Reset simple keys. */
-@@ -2574,7 +2621,7 @@
+@@ -2574,7 +2584,7 @@
  
      /* Resize the string to include the head. */
  
@@ -163,3 +158,29 @@ Index: libyaml-0.1.4/src/scanner.c
          if (!yaml_string_extend(&string.start, &string.pointer, &string.end)) {
              parser->error = YAML_MEMORY_ERROR;
              goto error;
+Index: libyaml-0.1.4/src/yaml_private.h
+===================================================================
+--- libyaml-0.1.4.orig/src/yaml_private.h	2011-05-29 01:55:42.000000000 -0400
++++ libyaml-0.1.4/src/yaml_private.h	2014-02-13 08:32:30.716856793 -0500
+@@ -7,6 +7,8 @@
+ 
+ #include <assert.h>
+ #include <limits.h>
++#include <stddef.h>
++#include <stdint.h>
+ 
+ /*
+  * Memory management.
+@@ -421,6 +423,12 @@
+ #define STACK_EMPTY(context,stack)                                              \
+     ((stack).start == (stack).top)
+ 
++#define STACK_LIMIT(context,stack,size)                                         \
++    ((stack).top - (stack).start < (size) ?                                     \
++        1 :                                                                     \
++        ((context)->error = YAML_MEMORY_ERROR,                                  \
++         0))
++
+ #define PUSH(context,stack,value)                                               \
+     (((stack).top != (stack).end                                                \
+       || yaml_stack_extend((void **)&(stack).start,                             \


### PR DESCRIPTION
The fix for CVE-2013-6393 introduced a regression that's since been
fixed in precise.  This change backports that fix to lucid.
