### PR TITLE
Remove lucid support from toolchain

### DIFF
--- a/pkg/rbenv/debian/changelog
+++ b/pkg/rbenv/debian/changelog
@@ -1,9 +1,3 @@
-rbenv (0.4.0-ppa1~lucid3) lucid; urgency=low
-
-  * Remove dependency on ruby
-
- -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Fri, 22 Nov 2013 11:50:44 +0000
-
 rbenv (0.4.0-ppa1~precise3) precise; urgency=low
 
   * Remove dependency on ruby

--- a/tools/sbuildinit
+++ b/tools/sbuildinit
@@ -2,7 +2,7 @@
 set -e
 
 ARCH="amd64"
-DISTS="lucid precise"
+DISTS="precise"
 
 # ensure the VM has enough entropy to generate sbuild's archive keys
 if ! dpkg -s haveged >/dev/null 2>&1; then 


### PR DESCRIPTION
No longer build a lucid schroot as we don't need to support lucid any
more.

Also remove the lucid changelog entry from the rbenv package as the
latest version of this has yet to be built.
