### PR TITLE
Check for build dependencies

### DIFF
--- a/build_source.py
+++ b/build_source.py
@@ -20,7 +20,7 @@ import tarfile
 import urllib
 import shutil
 
-from subprocess import Popen, PIPE
+from subprocess import call, Popen, PIPE
 
 class Changelog(object):
   """
@@ -55,8 +55,16 @@ class Package(object):
     self.tarfile = None
     self.expanded_dir = None
 
+    self.check_build_dependencies()
     self.read_srcurl()
     self.read_changelog()
+
+  def check_build_dependencies(self):
+    control_path = os.path.join(self.pkg_path, "debian", "control")
+    exit_code = call(['dpkg-checkbuilddeps', control_path])
+
+    if exit_code > 0:
+      sys.exit(1)
 
   def read_changelog(self):
     changelog_path = os.path.join(self.pkg_path, "debian", "changelog")


### PR DESCRIPTION
Use `dpkg-checkbuilddeps (1)`, part of `dpkg`, to check if a package's
build dependencies, as defined in the `debian/control` file, are met.

If not met, exit with a status code of `1`.

The reason for this is that I encountered an error when trying to build a
backport that depended on the `gem2deb` package. Below is the error that
occurred when `gem2deb` was not installed; installing this package using
`apt-get` resolved the issue.

``` bash
vagrant@packager:~/packager$ ./build_source.py pkg/ruby-hiera-eyaml/
=> creating build directory
=> fetching tarball
=> expanding tarball
=> copy new debian directory
=> debuild...
 dpkg-buildpackage -rfakeroot -d -us -uc -S
dpkg-buildpackage: export CFLAGS from dpkg-buildflags (origin: vendor): -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security
dpkg-buildpackage: export CPPFLAGS from dpkg-buildflags (origin: vendor): -D_FORTIFY_SOURCE=2
dpkg-buildpackage: export CXXFLAGS from dpkg-buildflags (origin: vendor): -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security
dpkg-buildpackage: export FFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export LDFLAGS from dpkg-buildflags (origin: vendor): -Wl,-Bsymbolic-functions -Wl,-z,relro
dpkg-buildpackage: source package ruby-hiera-eyaml
dpkg-buildpackage: source version 2.0.2-1
dpkg-buildpackage: source changed by Stig Sandbeck Mathisen <ssm@debian.org>
 dpkg-source --before-build ruby-hiera-eyaml-2.0.2
dpkg-source: info: patches are not applied, applying them now
dpkg-source: info: applying 0001-Do-not-require-rubygems.patch
 fakeroot debian/rules clean
dh clean --buildsystem=ruby --with ruby
dh: unable to load addon ruby: Can't locate Debian/Debhelper/Sequence/ruby.pm in @INC (@INC contains: /etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14 /usr/local/lib/site_perl .) at (eval 3) line 2.
BEGIN failed--compilation aborted at (eval 3) line 2.

make: *** [clean] Error 2
dpkg-buildpackage: error: fakeroot debian/rules clean gave error exit status 2
debuild: fatal error at line 1350:
dpkg-buildpackage -rfakeroot -d -us -uc -S failed
vagrant@packager:~/packager$
```
