### PR TITLE
Use the GOV.UK dev VM box for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,24 +3,35 @@
 
 MEMSIZE = "1024"
 NCPU = "2"
+#
+# NB: please don't use ruby 1.9 syntax in this file until the default system
+#     ruby shipping with Mac OS X becomes ruby 1.9
+#
+DIST_PREFERRED = 'precise'
+LATEST_BOX_VERSIONS = {
+  'precise' => '20140829',
+  'trusty'  => '20140829',
+}
 
 Vagrant.configure("2") do |config|
 
   config.vm.hostname = "packager"
 
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  default_box = "govuk_dev_#{DIST_PREFERRED}64_#{LATEST_BOX_VERSIONS[DIST_PREFERRED]}"
 
   config.vm.provider :virtualbox do |vb|
     vb.customize [ "modifyvm", :id, "--memory", MEMSIZE, "--cpus", NCPU ]
     vb.customize ["modifyvm", :id, "--rtcuseutc", "on"]
   end
+
   config.vm.provider :vmware_fusion do |f, override|
-    override.vm.box = "precise64_vmware_fusion"
-    override.vm.box_url = "http://files.vagrantup.com/precise64_vmware_fusion.box"
+    default_box = "govuk_dev_#{DIST_PREFERRED}64_vmware_fusion_#{LATEST_BOX_VERSIONS[DIST_PREFERRED]}"
     f.vmx["memsize"] = MEMSIZE
     f.vmx["numvcpus"] = NCPU
   end
+
+  config.vm.box = default_box
+  config.vm.box_url = "http://gds-boxes.s3.amazonaws.com/#{default_box}.box"
 
   config.vm.synced_folder ".", "/home/vagrant/packager"
 


### PR DESCRIPTION
Replace the Vagrant boxes obtained from `vagrantup.com` with the ones we
use for the GOV.UK development VM.

I hoped to use the official Ubuntu vagrant boxes[1](https://cloud-images.ubuntu.com/vagrant/precise/current/), but they don't
appear to provide one compatible with VMWare Fusion which some of the
team use.

The development VM vagrant boxes provide more than is strictly necessary
for building packages, i.e. they install Puppet.

That said, they're likely to be better maintained (as we're using them
regularly) and using them results in one less Vagrant box to pull down
from the web.

The GOV.UK dev Vagrant box for Precise currently installs version
`4.3.14 r95030` of VirtualBox guest additions. The version installed by
the `vagrantup.com` box was `4.1.12_Ubuntu r77245`.

Note that this `Vagrantfile` has been tested with Virtualbox but not
VMWare Fusion.

The reason for replacing the `vagrantup.com` boxes is that the
VirtualBox guest additions it installed were seemingly no longer
compatible with my version of VirtualBox (`4.3.10r93012`). In
particular, I saw some odd behaviour seemingly caused by VirtualBox
shared folders:

``` bash
vagrant@packager:~/packager$ rm -rf build/ruby-hiera-eyaml-2.0.2/
rm: cannot remove `build/ruby-hiera-eyaml-2.0.2/': Is a directory
```

`build_source.py` would also complain that
`build/ruby-hiera-eyaml-2.0.2/` already existed although checking for
that directory with `ls` on the VirtualBox host showed that the
directory did not in fact exist.
