### PR TITLE
Add clean target to ruby-hiera-eyaml/debian/rules

### DIFF
--- a/pkg/ruby-hiera-eyaml/debian/rules
+++ b/pkg/ruby-hiera-eyaml/debian/rules
@@ -11,5 +11,8 @@
 # If you need to specify the .gemspec (eg there is more than one)
 #export DH_RUBY_GEMSPEC=gem.gemspec
 
+clean:
+	dh $@
+
 %:
 	dh $@ --buildsystem=ruby --with ruby


### PR DESCRIPTION
Add a `clean` target to the `debian/rules` file for the `ruby-hiera-eyaml`
package. This prevents the following error, which occurs when
`--buildsystem=ruby --with ruby` is specified for the `clean` target when
running `dh`:

```
vagrant@packager:~/packager$ ./build_source.py pkg/ruby-hiera-eyaml/
=> creating build directory
=> fetching tarball
=> expanding tarball
=> copy new debian directory
=> debuild...
dpkg-buildpackage -rfakeroot -d -us -uc -S
dpkg-buildpackage: export CFLAGS from dpkg-buildflags (origin: vendor): -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security
dpkg-buildpackage: export CPPFLAGS from dpkg-buildflags (origin: vendor): -D_FORTIFY_SOURCE=2
dpkg-buildpackage: export CXXFLAGS from dpkg-buildflags (origin: vendor): -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security
dpkg-buildpackage: export FFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export LDFLAGS from dpkg-buildflags (origin: vendor): -Wl,-Bsymbolic-functions -Wl,-z,relro
dpkg-buildpackage: source package ruby-hiera-eyaml
dpkg-buildpackage: source version 2.0.2-1
dpkg-buildpackage: source changed by Stig Sandbeck Mathisen <ssm@debian.org>
dpkg-source --before-build ruby-hiera-eyaml-2.0.2
dpkg-source: info: patches are not applied, applying them now
dpkg-source: info: applying 0001-Do-not-require-rubygems.patch
fakeroot debian/rules clean
dh clean --buildsystem=ruby --with ruby
dh: unable to load addon ruby: Can't locate Debian/Debhelper/Sequence/ruby.pm in @INC (@INC contains: /etc/perl /usr/local/lib/perl/5.14.2 /usr/local/share/perl/5.14.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.14 /usr/share/perl/5.14 /usr/local/lib/site_perl .) at (eval 3) line 2.
BEGIN failed--compilation aborted at (eval 3) line 2.

make: *** [clean] Error 2
dpkg-buildpackage: error: fakeroot debian/rules clean gave error exit status 2
debuild: fatal error at line 1350:
dpkg-buildpackage -rfakeroot -d -us -uc -S failed
vagrant@packager:~/packager$
```

See also the discussion in https://github.com/alphagov/packager/pull/46
