### PR TITLE
Setup toolchain to build on a trusty VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ NCPU = "2"
 # NB: please don't use ruby 1.9 syntax in this file until the default system
 #     ruby shipping with Mac OS X becomes ruby 1.9
 #
-DIST_PREFERRED = 'precise'
+DIST_PREFERRED = 'trusty'
 LATEST_BOX_VERSIONS = {
   'precise' => '20140829',
   'trusty'  => '20140829',

--- a/doc/building_for_multiple_series.md
+++ b/doc/building_for_multiple_series.md
@@ -1,7 +1,7 @@
 # Building packages for multiple series
 
 It's not uncommon to want to build a package for multiple distribution series
-("Lucid", "Precise", etc.) from a single set of debian control files. This is
+("Trusty", "Precise", etc.) from a single set of debian control files. This is
 actually pretty easy to do, but if you want to submit the resulting packages to
 Launchpad there are a few more hoops to jump through. This document contains
 instructions on building for multiple series.
@@ -10,38 +10,38 @@ instructions on building for multiple series.
 
 Launchpad will only permit one set of binaries for a given package at a given
 version within a single PPA. This means that you cannot have, for example,
-`collectd-5.3.0-ppa8` for Precise and `collectd-5.3.0-ppa8` for Lucid published
+`collectd-5.3.0-ppa8` for Precise and `collectd-5.3.0-ppa8` for Trusty published
 to the same PPA.
 
 The simplest way to work around this is to put the distribution series code name
-into the version number. A common pattern is to append `~lucid` or `~precise` as
+into the version number. A common pattern is to append `~trusty` or `~precise` as
 appropriate.
 
-I recommend you append `~lucid1` or similar, so that if you have to modify the
+I recommend you append `~trusty1` or similar, so that if you have to modify the
 build scripts (and not the underlying package) in a way that affects only one
-series, you have the ability to bump the version number to `~lucid2` and release
+series, you have the ability to bump the version number to `~trusty2` and release
 a new version.
 
 ## The process
 
 Let's say you're have `collectd` at version `5.3.0-ppa8` and you wish to release
-`5.3.0-ppa9` for both Lucid and Precise.
+`5.3.0-ppa9` for both Trusty and Precise.
 
 Make sure your package builds on all series you wish to build for:
 
     $ ./build_source.py pkg/collectd
     $ sbuild -A -d precise-amd64 build/collectd/collectd_5.3.0-ppa8.dsc
-    $ sbuild -A -d lucid-amd64 build/collectd/collectd_5.3.0-ppa8.dsc
+    $ sbuild -A -d trusty-amd64 build/collectd/collectd_5.3.0-ppa8.dsc
 
-If this is successful, then for *both* Lucid and Precise, you will need to add
+If this is successful, then for *both* Trusty and Precise, you will need to add
 an entry to the changelog, rebuild the source package, and submit the `.changes`
 file to Launchpad:
 
     $ cd build/collectd/collect-5.3.0/
-    $ dch -v '5.3.0-ppa9~lucid1' -D lucid
+    $ dch -v '5.3.0-ppa9~trusty1' -D trusty
     $ cd ../../../
     $ ./build_source.py pkg/collectd
-    $ dput ppa:gds/govuk build/collectd/collectd_5.3.0-ppa9~lucid1_source.changes
+    $ dput ppa:gds/govuk build/collectd/collectd_5.3.0-ppa9~trusty1_source.changes
     $ cd build/collectd/collect-5.3.0/
     $ dch -v '5.3.0-ppa9~precise1' -D precise
     $ cd ../../../

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -54,7 +54,7 @@ produced by `./build_source.py`:
 Building packages for multiple series
 -------------------------------------
 
-Building packages for multiple series ("Precise", "Lucid", etc.) is slightly
+Building packages for multiple series ("Precise", "Trusty", etc.) is slightly
 more involved. See [`building_for_multiple_series.md`](building_for_multiple_series.md).
 
 Submitting to Launchpad

--- a/tools/sbuildinit
+++ b/tools/sbuildinit
@@ -2,7 +2,7 @@
 set -e
 
 ARCH="amd64"
-DISTS="precise"
+DISTS="precise trusty"
 
 # ensure the VM has enough entropy to generate sbuild's archive keys
 if ! dpkg -s haveged >/dev/null 2>&1; then 


### PR DESCRIPTION
Also update docs to refer to Precise and Trusty as opposed to Lucid and
Precise.

This will make the packager VM run trusty instead of precise, so that
the more recent tools will be available to build_source.py.  The actual
builds still happen with a schroot for the appropriate distro (or at
launchpad...).
