### PR TITLE
Build mawk-1.3.4 for trusty

### DIFF
--- a/pkg/mawk-1.3.4/debian/changelog
+++ b/pkg/mawk-1.3.4/debian/changelog
@@ -1,3 +1,9 @@
+mawk-1.3.4 (1-ppa1~trusty1) trusty; urgency=medium
+
+  * Build for trusty
+
+ -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Thu, 02 Oct 2014 15:58:50 +0000
+
 mawk-1.3.4 (1-ppa1~precise1) precise; urgency=low
 
   * Change package name

--- a/pkg/mawk-1.3.4/debian/control
+++ b/pkg/mawk-1.3.4/debian/control
@@ -5,7 +5,7 @@ Maintainer: Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>
 XSBC-Original-Maintainer: Steve Langasek <vorlon@debian.org>
 Build-Depends: quilt (>= 0.46-7), bison, debhelper (>= 8.9.4)
 Build-Conflicts: byacc
-Standards-Version: 3.9.3
+Standards-Version: 3.9.5
 
 Package: mawk-1.3.4
 Architecture: any


### PR DESCRIPTION
This is the package that installs into /opt so that it can coexist with the ubuntu version.
