### PR TITLE
Build vegeta on trusty.

### DIFF
--- a/pkg/vegeta/debian/changelog
+++ b/pkg/vegeta/debian/changelog
@@ -1,3 +1,9 @@
+vegeta (0.0.1-1517f2d~ppa3) trusty; urgency=medium
+
+  * Build on trusty
+
+ -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Fri, 03 Oct 2014 11:10:06 +0000
+
 vegeta (0.0.1-1517f2d~ppa2~precise) precise; urgency=low
 
   * Include bmizerany/perks dependency as a patch. Because the Launchpad

--- a/pkg/vegeta/debian/control
+++ b/pkg/vegeta/debian/control
@@ -3,7 +3,7 @@ Section: web
 Priority: extra
 Maintainer: Dan Carley <dan.carley@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), golang-go (>= 2:1.1), git
-Standards-Version: 3.9.2
+Standards-Version: 3.9.5
 Homepage: https://github.com/tsenart/vegeta
 
 Package: vegeta


### PR DESCRIPTION
This removes the build-dependency on our custom golang package (trusty
ships with 1.2). This also removes the release specific part from the
version - the resulting binary packages will work on both precise and
trusty because Go binaries ave very minimal dependencies.
