### PR TITLE
Remove 'Uploaders' field from debian/control

### DIFF
--- a/pkg/ruby-hiera-eyaml-gpg/debian/control
+++ b/pkg/ruby-hiera-eyaml-gpg/debian/control
@@ -1,6 +1,5 @@
 Source: ruby-hiera-eyaml-gpg
 Maintainer: Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>
-Uploaders: Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>
 Section: ruby
 Priority: optional
 Build-Depends: debhelper (>= 7.0.50~),

--- a/pkg/ruby-highline/debian/control
+++ b/pkg/ruby-highline/debian/control
@@ -3,7 +3,6 @@ Section: ruby
 Priority: optional
 Maintainer: Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>
 XSBC-Original-Maintainer: Debian Ruby Extras Maintainers <pkg-ruby-extras-maintainers@lists.alioth.debian.org>
-Uploaders: Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>
 Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.2.13~)
 Standards-Version: 3.9.5
 Vcs-Git: git://anonscm.debian.org/pkg-ruby-extras/ruby-highline.git

--- a/pkg/ruby-trollop/debian/control
+++ b/pkg/ruby-trollop/debian/control
@@ -3,7 +3,6 @@ Section: ruby
 Priority: extra
 Maintainer: Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>
 XSBC-Original-Maintainer: Debian Ruby Extras Maintainers <pkg-ruby-extras-maintainers@lists.alioth.debian.org>
-Uploaders: Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>
 Build-Depends: debhelper (>= 7.0.50~), gem2deb (>= 0.2.13~)
 Standards-Version: 3.9.5
 Vcs-Git: git://anonscm.debian.org/pkg-ruby-extras/ruby-trollop.git


### PR DESCRIPTION
`dpkg-buildpackage` complains if the maintainer field is the same as the
uploader field in `debian/control`:

```
W: ruby-trollop source: maintainer-also-in-uploaders
```

Remove the 'Uploaders' field to resolve this.
