### PR TITLE
Add clean target to Ruby gem packages

### DIFF
--- a/pkg/ruby-hiera-eyaml-gpg/debian/rules
+++ b/pkg/ruby-hiera-eyaml-gpg/debian/rules
@@ -1,4 +1,7 @@
 #!/usr/bin/make -f
 
+clean:
+	dh $@
+
 %:
 	dh $@ --buildsystem=ruby --with ruby

--- a/pkg/ruby-highline/debian/rules
+++ b/pkg/ruby-highline/debian/rules
@@ -11,5 +11,8 @@
 # If you need to specify the .gemspec (eg there is more than one)
 #export DH_RUBY_GEMSPEC=gem.gemspec
 
+clean:
+	dh $@
+
 %:
 	dh $@ --buildsystem=ruby --with ruby

--- a/pkg/ruby-trollop/debian/rules
+++ b/pkg/ruby-trollop/debian/rules
@@ -11,5 +11,8 @@
 # If you need to specify the .gemspec (eg there is more than one)
 #export DH_RUBY_GEMSPEC=gem.gemspec
 
+clean:
+	dh $@
+
 %:
 	dh $@ --buildsystem=ruby --with ruby


### PR DESCRIPTION
65f7983 added a `clean` target to `debian/rules` for the
`ruby-hiera-eyaml` package to prevent build errors.

This commit does the same, but for the `ruby-highline`, `ruby-trollop`
and `ruby-hiera-eyaml-gpg` packages.
