### PR TITLE
Update versioning for godep.

### DIFF
--- a/pkg/godep/debian/changelog
+++ b/pkg/godep/debian/changelog
@@ -1,5 +1,5 @@
-godep (0.0.1-104-gedcaa96-1~ppa1) trusty; urgency=medium
+godep (0-105-g754ee6f-1~ppa1) trusty; urgency=medium
 
-  * Initial package release of git master at revision edcaa96.
+  * Initial package release of git master at revision 754ee6f.
 
  -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Fri, 26 Sep 2014 13:44:48 +0000

--- a/pkg/godep/srcurl
+++ b/pkg/godep/srcurl
@@ -1,1 +1,1 @@
-https://github.com/tools/godep/archive/edcaa96f040b31f4186738decac57f88d6061b8d.tar.gz
+https://github.com/tools/godep/archive/754ee6f4e0e5fc8d0ef2692fb239d15c7a09dd84.tar.gz


### PR DESCRIPTION
The upstream author has now [created a tag](https://github.com/tools/godep/issues/126) for the first commit in the repo.  This means we can now use version numbers as generated by `git describe`.

This has resulted in a decrease in the version number, which may need to be cleaned up manually.  As this hasn't been deployed widely yet, this isn't a big deal.
