### PR TITLE
[#80633966] Release ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8)

### DIFF
--- a/pkg/ruby-hiera-eyaml-gpg/debian/changelog
+++ b/pkg/ruby-hiera-eyaml-gpg/debian/changelog
@@ -1,3 +1,25 @@
+ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8-1~trusty1) trusty; urgency=low
+
+  * Package from fork at
+    https://github.com/alphagov/hiera-eyaml-gpg/tree/avoid_gpghome_env_var
+
+  * Set GPG home directory without using the GPGHOME environment
+    variable. See:
+    https://github.com/alphagov/hiera-eyaml-gpg/commit/00e95645e050928bbd137aceb35e7196bc72341e
+
+ -- Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>  Fri, 16 Oct 2014 16:39:42 +0100
+
+ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8-1~precise1) precise; urgency=low
+
+  * Package from fork at
+    https://github.com/alphagov/hiera-eyaml-gpg/tree/avoid_gpghome_env_var
+
+  * Set GPG home directory without using the GPGHOME environment
+    variable. See:
+    https://github.com/alphagov/hiera-eyaml-gpg/commit/00e95645e050928bbd137aceb35e7196bc72341e
+
+ -- Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>  Fri, 16 Oct 2014 16:39:42 +0100
+
 ruby-hiera-eyaml-gpg (0.4-1~trusty1) trusty; urgency=low
 
   * Initial release

--- a/pkg/ruby-hiera-eyaml-gpg/srcurl
+++ b/pkg/ruby-hiera-eyaml-gpg/srcurl
@@ -1,1 +1,1 @@
-https://github.com/sihil/hiera-eyaml-gpg/archive/v0.4.tar.gz
+https://github.com/alphagov/hiera-eyaml-gpg/archive/b10d8a890a4aff78b90e4662fe1e2d5b1690937b.tar.gz


### PR DESCRIPTION
Using the fork at:
https://github.com/alphagov/hiera-eyaml-gpg/tree/avoid_gpghome_env_var

This includes a change to set the GPG home directory without using the
GPGHOME environment variable.
