### PR TITLE
[#80633966] Release ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8)

### DIFF
--- a/pkg/ruby-hiera-eyaml-gpg/debian/changelog
+++ b/pkg/ruby-hiera-eyaml-gpg/debian/changelog
@@ -1,4 +1,4 @@
-ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8-1~trusty1) trusty; urgency=low
+ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8-1~trusty2) trusty; urgency=low
 
   * Package from fork at
     https://github.com/alphagov/hiera-eyaml-gpg/tree/avoid_gpghome_env_var
@@ -9,7 +9,7 @@ ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8-1~trusty1) trusty; urgency=low
 
  -- Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>  Fri, 16 Oct 2014 16:39:42 +0100
 
-ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8-1~precise1) precise; urgency=low
+ruby-hiera-eyaml-gpg (0.4-5-gb10d8a8-1~precise2) precise; urgency=low
 
   * Package from fork at
     https://github.com/alphagov/hiera-eyaml-gpg/tree/avoid_gpghome_env_var

--- a/pkg/ruby-hiera-eyaml-gpg/srcurl
+++ b/pkg/ruby-hiera-eyaml-gpg/srcurl
@@ -1,1 +1,1 @@
-https://github.com/alphagov/hiera-eyaml-gpg/archive/avoid_gpghome_env_var.tar.gz
+https://github.com/alphagov/hiera-eyaml-gpg/archive/b10d8a890a4aff78b90e4662fe1e2d5b1690937b.tar.gz


### PR DESCRIPTION
Using the fork at:
https://github.com/alphagov/hiera-eyaml-gpg/tree/avoid_gpghome_env_var

This includes a change to set the GPG home directory without using the
GPGHOME environment variable.

---

Supersedes #75; this PR adds d6ea556 following @alext's feedback.
