### PR TITLE
[#73607174] Upgrade locksmithctl to version 0.2.2

### DIFF
--- a/pkg/locksmithctl/debian/changelog
+++ b/pkg/locksmithctl/debian/changelog
@@ -1,3 +1,10 @@
+locksmithctl (0.2.2-ppa1) trusty; urgency=low
+
+  * Upgrade to upstream version 0.2.2.
+  * From tag: https://github.com/coreos/locksmith/releases/tag/v0.2.2
+
+ -- Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>  Wed, 10 Dec 2014 14:04:37 +0000
+
 locksmithctl (0.1.8-ppa2) trusty; urgency=low
 
   * Initial package release.

--- a/pkg/locksmithctl/srcurl
+++ b/pkg/locksmithctl/srcurl
@@ -1,1 +1,1 @@
-https://github.com/coreos/locksmith/archive/v0.1.8.tar.gz
+https://github.com/coreos/locksmith/archive/v0.2.2.tar.gz


### PR DESCRIPTION
Version 0.2.2 supports the `-endpoint` flag to specify an etcd client
URL:
https://github.com/coreos/locksmith/commit/e3fe40126e3e5ff3d350be116c6f136e007b65c5#diff-3ceac677474a0ac6dbeeba6c665ebf75
