### PR TITLE
[#88491012] Upgrade locksmith from 0.2.2 to 0.2.3

### DIFF
--- a/pkg/locksmithctl/debian/changelog
+++ b/pkg/locksmithctl/debian/changelog
@@ -1,3 +1,10 @@
+locksmithctl (0.2.3-ppa1) trusty; urgency=low
+
+  * Upgrade to upstream version 0.2.3.
+  * From tag: https://github.com/coreos/locksmith/releases/tag/v0.2.3
+
+ -- Alex Muller (Government Digital Service GDS) <alex.muller@digital.cabinet-office.gov.uk>  Wed, 18 Feb 2015 08:10:30 +0000
+
 locksmithctl (0.2.2-ppa1) trusty; urgency=low
 
   * Upgrade to upstream version 0.2.2.

--- a/pkg/locksmithctl/srcurl
+++ b/pkg/locksmithctl/srcurl
@@ -1,1 +1,1 @@
-https://github.com/coreos/locksmith/archive/v0.2.2.tar.gz
+https://github.com/coreos/locksmith/archive/v0.2.3.tar.gz


### PR DESCRIPTION
Version 0.2.3 supports multiple endpoints for etcd.

This is my first commit to packager, so I've just copied prior art for doing this.