### PR TITLE
[goenv] Add bin symlink alongside libexec dir

### DIFF
--- a/pkg/goenv/debian/changelog
+++ b/pkg/goenv/debian/changelog
@@ -1,3 +1,9 @@
+goenv (0.0.6-alext-1~ppa2) trusty; urgency=medium
+
+  * Add /usr/lib/goenv/bin/goenv symlink to fix goenv-install
+
+ -- Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>  Wed, 18 Mar 2015 08:58:59 +0000
+
 goenv (0.0.6-alext-1~ppa1) trusty; urgency=medium
 
   * New upstream version 0.0.6

--- a/pkg/goenv/debian/control
+++ b/pkg/goenv/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Alex Tomlins <alex.tomlins@digital.cabinet-office.gov.uk>
 Build-Depends: debhelper (>= 7.0.50)
-Standards-Version: 3.9.3
+Standards-Version: 3.9.5
 Homepage: https://github.com/alext/goenv
 
 Package: goenv

--- a/pkg/goenv/debian/goenv.links
+++ b/pkg/goenv/debian/goenv.links
@@ -1,1 +1,2 @@
 usr/lib/goenv/libexec/goenv usr/bin/goenv
+usr/lib/goenv/libexec/goenv usr/lib/goenv/bin/goenv


### PR DESCRIPTION
Some of the tools (eg goenv-install) assume that the bin dir will be
alongside the libexec dir.  This amends the install to create this dir
with the necessary symlink in it, in addition to the /usr/bin/goenv
symlink.