### PR TITLE
Package grafana for trusty

### DIFF
--- a/pkg/grafana/debian/changelog
+++ b/pkg/grafana/debian/changelog
@@ -1,3 +1,9 @@
+grafana (1.5.2~ppa1~trusty) trusty; urgency=low
+
+  * Initial build for trusty.
+
+ -- Alex Muller (Government Digital Service GDS) <alex.muller@digital.cabinet-office.gov.uk>  Wed, 22 Jul 2015 15:06:28 +0000
+
 grafana (1.5.2~ppa1~precise) precise; urgency=low
 
   * Initial build.

--- a/pkg/grafana/srcurl
+++ b/pkg/grafana/srcurl
@@ -1,1 +1,1 @@
-https://github.com/torkelo/grafana/releases/download/v1.5.2/grafana-1.5.2.tar.gz
+https://github.com/grafana/grafana/releases/download/v1.5.2/grafana-1.5.2.tar.gz


### PR DESCRIPTION
I've uploaded this package to Launchpad but it's not appearing yet: https://launchpad.net/~gds/+archive/ubuntu/govuk/+packages

```
Uploading to ppa (via ftp to ppa.launchpad.net):
  Uploading grafana_1.5.2~ppa1~trusty.dsc: done.
  Uploading grafana_1.5.2~ppa1~trusty.orig.tar.gz: done.    
  Uploading grafana_1.5.2~ppa1~trusty.debian.tar.gz: done.
  Uploading grafana_1.5.2~ppa1~trusty_source.changes: done.
Successfully uploaded packages.
```