### PR TITLE
Upgrade Grafana to version 1.9.1

### DIFF
--- a/pkg/grafana/debian/changelog
+++ b/pkg/grafana/debian/changelog
@@ -1,3 +1,15 @@
+grafana (1.9.1~ppa1~trusty) trusty; urgency=low
+
+  * Upgrade to version 1.9.1.
+
+ -- Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>  Thu, 3 Sep 2015 16:41:29 +0000
+
+grafana (1.9.1~ppa1~precise) precise; urgency=low
+
+  * Upgrade to version 1.9.1.
+
+ -- Matt Bostock <matt.bostock@digital.cabinet-office.gov.uk>  Thu, 3 Sep 2015 16:41:29 +0000
+
 grafana (1.5.2~ppa1~trusty) trusty; urgency=low
 
   * Initial build for trusty.

--- a/pkg/grafana/srcurl
+++ b/pkg/grafana/srcurl
@@ -1,1 +1,1 @@
-https://github.com/grafana/grafana/releases/download/v1.5.2/grafana-1.5.2.tar.gz
+https://grafanarel.s3.amazonaws.com/grafana-1.9.1.tar.gz


### PR DESCRIPTION
Upgrade Grafana to version 1.9.1, which is the latest version in the 1.x
series.

This version includes the single stat panel, which I'd like to make use
of:
http://docs.grafana.org/reference/singlestat/

I haven't upgraded to version 2.x because it uses a new architecture
including a backend server which would require further changes; version
1.9.1 provides what I need for now.

These packages have successfully uploaded to the GOV.UK PPA.