### PR TITLE
Fix gor version

### DIFF
--- a/pkg/gor/debian/changelog
+++ b/pkg/gor/debian/changelog
@@ -1,4 +1,4 @@
-gor (0.10.1~ppa1) trusty; urgency=low
+gor (0.10.1~ppa2) trusty; urgency=low
 
   * Upgrade to version 0.10.1. See changelog:
     https://github.com/buger/gor/releases

--- a/pkg/gor/debian/rules
+++ b/pkg/gor/debian/rules
@@ -2,6 +2,7 @@
 
 export GOPATH=$(CURDIR)
 export GOBIN=$(CURDIR)/debian/gor/usr/bin
+export VERSION="0.10.1"
 
 %:
 	dh $@
@@ -12,4 +13,4 @@ export GOBIN=$(CURDIR)/debian/gor/usr/bin
 override_dh_auto_build:
 	mkdir -p src/github.com/buger/
 	ln -s ../../../ src/github.com/buger/gor
-	go build -o gor
+	go build -o gor -ldflags "-X main.VERSION $(VERSION)"


### PR DESCRIPTION
For the recent package of Gor that was built `gor_0.10.1~ppa1_amd64.deb` the flag to set VERSION was not set during the build stage. This meant that we would have:

```
joshmyers@staging-cache-1:~$ gor --help
Version:
```

With this changes the new `gor_0.10.1~ppa2_amd64.deb` package has VERSION set:

```
vagrant@packager:~/packager$ gor --help
Version: 0.10.1
```