### PR TITLE
Gor 0.10.1 is having issues, downgrade to 0.9.4.

### DIFF
--- a/pkg/gor/debian/changelog
+++ b/pkg/gor/debian/changelog
@@ -1,6 +1,6 @@
-gor (0.10.1~ppa2) trusty; urgency=low
+gor (0.9.4~ppa1) trusty; urgency=low
 
-  * Upgrade to version 0.10.1. See changelog:
+  * Upgrade to version 0.9.4. See changelog:
     https://github.com/buger/gor/releases
 
  -- Josh Myers <josh.myers@digital.cabinet-office.gov.uk>  Fri, 4 Sep 2015 14:03:48 +0000

--- a/pkg/gor/srcurl
+++ b/pkg/gor/srcurl
@@ -1,1 +1,1 @@
-https://github.com/buger/gor/archive/766bbc6127fe092fb8236188bc4ed946f375364e.tar.gz
+https://github.com/buger/gor/archive/6fe7ba8e86fd4234a9987c2f730304dfc292c516.tar.gz


### PR DESCRIPTION
Gor 0.10.1 is replaying traffic but not the same
levels of traffic are hitting targets. Gor looks
to have had a significant rewrite from 0.7.X
(previous working version) and 0.10.X. Gor version
0.9.4 is the latest version which seems to give us
the same level of traffic replay. Downgrade to
this version now to get traffic replay working
again.

![screen shot 2015-09-08 at 14 51 02](https://cloud.githubusercontent.com/assets/3025844/9737895/cc78b03c-5640-11e5-8465-a87d6a54e5b3.png)

The first and second large peaks here are Gor@0.7.0, the smaller peaks are Gor releases just before 0.10.1. You can see that Gor 0.9.6 - 0.10.1 never seems to replay the same amount of traffic as 0.7.0. The last large peak on the right hand side is Gor@0.9.4, which is the most up to date release that gave us this "good" level of traffic replay, while also giving us the regex functionality `-output-http-url-regexp`

It should also be noted that with the latest Gor@0.10.1 I saw quite a few errors such as below, which don't seem to happen with Gor@0.9.4:

```
2015/09/08 12:26:38 Received packet with same sequence
2015/09/08 12:26:38 Received packet with same sequence
2015/09/08 12:30:21 Received packet with same sequence
2015/09/08 12:30:54 Received packet with same sequence
```
```
2015/09/08 12:17:03 PANIC: pkg: runtime error: slice bounds out of range /build/gor-zXReOK/gor-0.10.1~ppa1/src/github.com/buger/gor/raw_socket_listener/listener.go:199 (0x5379f5)
/usr/lib/go/src/pkg/runtime/panic.c:248 (0x427c16)
/usr/lib/go/src/pkg/runtime/panic.c:482 (0x4284bd)
/usr/lib/go/src/pkg/runtime/panic.c:439 (0x428307)
/build/gor-zXReOK/gor-0.10.1~ppa1/src/github.com/buger/gor/raw_socket_listener/listener.go:237 (0x53530b)
/build/gor-zXReOK/gor-0.10.1~ppa1/src/github.com/buger/gor/raw_socket_listener/listener.go:100 (0x5340dd)
/usr/lib/go/src/pkg/runtime/proc.c:1394 (0x42bf20)
```

I propose we pull the Gor 0.10.1 package from Launchpad/Aptly, publish the `gor_0.9.4~ppa1_amd64.deb` package and have machines use this version of Gor instead.

Happy to investigate more as to why this issue happens with Gor, possibly with someone with some GO experience. A [diff](https://github.com/buger/gor/compare/6fe7ba8...v0.10.1) of the changes between 0.9.4 - 0.10.1