### PR TITLE
Provide fpm recipe to build ruby 2.3.1

### DIFF
--- a/fpm/recipes/ruby-2.3.1/recipe.rb
+++ b/fpm/recipes/ruby-2.3.1/recipe.rb
@@ -1,0 +1,32 @@
+class RbenvRuby231 < FPM::Cookery::Recipe
+
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.3.1'
+  version '1'
+
+  source "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.1.tar.gz"
+  sha256 'b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.3.1'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end


### PR DESCRIPTION
We (@gpeng and I) temporarily made jenkins build from this branch (see: https://deploy.publishing.service.gov.uk/job/build_fpm_package/5/) and successfully installed ruby 2.3.1 from the resulting deb in a dev vm.

For https://github.com/alphagov/govuk-puppet/pull/4755 (or https://github.com/alphagov/govuk-puppet/pull/4651)