### PR TITLE
Create packages for hiera-eyaml

### DIFF
--- a/fpm/recipes/rubygem-hiera-eyaml-gpg/recipe.rb
+++ b/fpm/recipes/rubygem-hiera-eyaml-gpg/recipe.rb
@@ -1,0 +1,4 @@
+class RubyHieraEyamlGPG < FPM::Cookery::RubyGemRecipe
+  name    "hiera-eyaml-gpg"
+  version "0.6"
+end

--- a/fpm/recipes/rubygem-hiera-eyaml/recipe.rb
+++ b/fpm/recipes/rubygem-hiera-eyaml/recipe.rb
@@ -1,0 +1,4 @@
+class RubyHieraEyaml < FPM::Cookery::RubyGemRecipe
+  name    "hiera-eyaml"
+  version "2.1.0"
+end


### PR DESCRIPTION
This creates the packages for both hiera-eyaml and hiera-eyaml-gpg. We previously packaged these up to go on PPA, but did not have them available for a Xenial release. This uses the built in fpm-cookery function to create a package directly from rubygems. The end result are packages called "rubygem-hiera-eyaml" and "rubygem-hiera-eyaml-gpg" respectively.

fpm functionality described here:
https://github.com/jordansissel/fpm/wiki/ConvertingGems