### PR TITLE
Create Xenial hiera-eyaml-gpg package

### DIFF
--- a/fpm/recipes/rubygem-hiera-eyaml-gpg/recipe.rb
+++ b/fpm/recipes/rubygem-hiera-eyaml-gpg/recipe.rb
@@ -1,4 +1,24 @@
-class RubyHieraEyamlGPG < FPM::Cookery::RubyGemRecipe
-  name    "hiera-eyaml-gpg"
-  version "0.6"
+class RubyHieraEyamlGpg < FPM::Cookery::Recipe
+  # Do not use the RubyGemRecipe class as that will not cope with
+  # environments running rbenv. Instead write a custom recipe that will
+  # install ruby gems in standard ruby_vendors directory.
+  name    'rubygem-hiera-eyaml-gpg'
+  version '0.4'
+  homepage 'https://github.com/sihil/hiera-eyaml-gpg'
+
+  source "https://github.com/sihil/hiera-eyaml-gpg/archive/v#{version}.tar.gz"
+  sha256 "bd1d3fb2197af14420efa9e598e99d6fc9b659dd429e58c70ea7c457b742dd16"
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+
+  depends 'hiera-eyaml (>=1.3.8)', 'ruby-gpgme (>=2.0.0)'
+
+  def build
+  end
+
+  def install
+    full_name = "hiera-eyaml-gpg-#{version}"
+    safesystem "mkdir -p #{destdir}/usr/lib/ruby/vendor_ruby"
+    safesystem "cp -fR #{builddir}/#{full_name}/lib/* #{destdir}/usr/lib/ruby/vendor_ruby/."
+  end
 end

--- a/fpm/recipes/rubygem-hiera-eyaml/recipe.rb
+++ b/fpm/recipes/rubygem-hiera-eyaml/recipe.rb
@@ -1,4 +1,0 @@
-class RubyHieraEyaml < FPM::Cookery::RubyGemRecipe
-  name    "hiera-eyaml"
-  version "2.1.0"
-end


### PR DESCRIPTION
Xenial does not provide a package for hiera-eyaml-gpg (although it does for hiera-eyaml) which we use for encrypting hiera files so we have to make our own package.

fpm-cookery does provide a 'RubyGemRecipe' but it mimics whichever install path the enviroment uses for gems. This causes problems when e.g. rbenv is being used as the package will install gems to directories that aren't in PATH. To make sure we always use the standard install location we have hard coded the paths in this recipe.