### PR TITLE
Remove rubygem recipes

### DIFF
--- a/fpm/recipes/rubygem-hiera-eyaml-gpg/recipe.rb
+++ b/fpm/recipes/rubygem-hiera-eyaml-gpg/recipe.rb
@@ -1,4 +1,0 @@
-class RubyHieraEyamlGPG < FPM::Cookery::RubyGemRecipe
-  name    "hiera-eyaml-gpg"
-  version "0.6"
-end

--- a/fpm/recipes/rubygem-hiera-eyaml/recipe.rb
+++ b/fpm/recipes/rubygem-hiera-eyaml/recipe.rb
@@ -1,4 +1,0 @@
-class RubyHieraEyaml < FPM::Cookery::RubyGemRecipe
-  name    "hiera-eyaml"
-  version "2.1.0"
-end


### PR DESCRIPTION
The hiera-eyaml and hiera-eyaml-gpg packages were added for use in xenial but these are no longer needed as they will be installed using `gem install`