### PR TITLE
Add latest version of wkhtmltopdf

### DIFF
--- a/fpm/recipes/wkhtmltopdf/recipe.rb
+++ b/fpm/recipes/wkhtmltopdf/recipe.rb
@@ -1,0 +1,24 @@
+class Wkhtmltopdf < FPM::Cookery::Recipe
+  name 'wkhtmltopdf'
+  homepage 'https://wkhtmltopdf.org/'
+
+  version '0.12.4'
+
+  source "https://downloads.wkhtmltopdf.org/#{minor_version}/#{version}/wkhtmltox-#{version}_linux-generic-amd64.tar.xz"
+  sha256 '049b2cdec9a8254f0ef8ac273afaf54f7e25459a273e27189591edc7d7cf29db'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'LGPLv3'
+
+  def minor_version
+    version.split('.').take(2).join('.')
+  end
+
+  def build
+  end
+
+  def install
+    safesystem "mkdir -p #{destdir}/usr/local/bin/"
+    safesystem "cp -f #{builddir}/bin/#{name} #{destdir}/usr/local/bin/"
+  end
+end


### PR DESCRIPTION
This commit adds a recipe to download the latest version of wkhtmltopdf
and how to install it.

Questions:
- How can I test if this works?
- How do I use this in conjunction with puppet? I.e. how do I now install this version on the servers?
- What is `builddir`? I'm asking because the name of the directory after extracting the file is `wkhtmltox`, so not sure if I'm copying from the right place.
- The binary seems to work fine without copying the rest of the files to the expected places (see tree structure below), is it enough to copy the binary?

```
wkhtmltox
├── bin
│   ├── wkhtmltoimage
│   └── wkhtmltopdf
├── include
│   └── wkhtmltox
│       ├── dllbegin.inc
│       ├── dllend.inc
│       ├── image.h
│       └── pdf.h
├── lib
│   ├── libwkhtmltox.so -> libwkhtmltox.so.0.12.4
│   ├── libwkhtmltox.so.0 -> libwkhtmltox.so.0.12.4
│   ├── libwkhtmltox.so.0.12 -> libwkhtmltox.so.0.12.4
│   └── libwkhtmltox.so.0.12.4
└── share
    └── man
        └── man1
            ├── wkhtmltoimage.1.gz
            └── wkhtmltopdf.1.gz

```