### PR TITLE
Upgrade fpm and fpm-cookery gems

### DIFF
--- a/fpm/Gemfile
+++ b/fpm/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org/'
 
-gem 'fpm', '1.4.0'
-gem 'fpm-cookery', '0.31.0'
+gem 'fpm', '1.9.2'
+gem 'fpm-cookery', '0.32.0'

--- a/fpm/Gemfile.lock
+++ b/fpm/Gemfile.lock
@@ -1,45 +1,63 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.2.8)
-    addressable (2.4.0)
+    CFPropertyList (2.3.5)
+    addressable (2.3.8)
     arr-pm (0.0.10)
       cabin (> 0)
-    backports (3.6.8)
-    cabin (0.8.1)
-    childprocess (0.5.9)
+    backports (3.8.0)
+    cabin (0.9.0)
+    childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
-    clamp (0.6.5)
-    facter (2.4.6)
-      CFPropertyList (~> 2.2.6)
-    ffi (1.9.10)
-    fpm (1.4.0)
+    clamp (1.0.1)
+    dotenv (2.2.1)
+    facter (2.5.0)
+      CFPropertyList (~> 2.2)
+    ffi (1.9.18)
+    fpm (1.9.2)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
       childprocess
-      clamp (~> 0.6)
+      clamp (~> 1.0.0)
       ffi
-      json (>= 1.7.7)
-    fpm-cookery (0.31.0)
-      addressable
+      json (>= 1.7.7, < 2.0)
+      pleaserun (~> 0.0.29)
+      ruby-xz
+      stud
+    fpm-cookery (0.32.0)
+      addressable (~> 2.3.8)
       facter
       fpm (~> 1.1)
       puppet (~> 3.4)
       systemu
     hiera (1.3.4)
       json_pure
-    json (1.8.3)
-    json_pure (1.8.3)
-    puppet (3.8.6)
+    insist (1.0.0)
+    io-like (0.3.0)
+    json (1.8.6)
+    json_pure (2.1.0)
+    mustache (0.99.8)
+    pleaserun (0.0.30)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    puppet (3.8.7)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
+    ruby-xz (0.2.3)
+      ffi (~> 1.9)
+      io-like (~> 0.3)
+    stud (0.0.23)
     systemu (2.6.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  fpm (= 1.4.0)
-  fpm-cookery (= 0.31.0)
+  fpm (= 1.9.2)
+  fpm-cookery (= 0.32.0)


### PR DESCRIPTION
Upgrade fpm to 1.9.2:
https://github.com/jordansissel/fpm/compare/v1.4.0...v1.9.2

Upgrade fpm-cookery to 0.32.0
https://github.com/bernd/fpm-cookery/compare/v0.31.0...v0.32.0

fpm-cookery v0.33.0 has a commit that breaks local sources, so for now
we are going to stay on 0.32.0:
https://github.com/bernd/fpm-cookery/commit/a3ac3345b11a559386e63d5a86799091ef968051