### PR TITLE
Add logstash 1.1.9

### DIFF
--- a/fpm/recipes/logstash/README.md
+++ b/fpm/recipes/logstash/README.md
@@ -1,0 +1,8 @@
+## Create Logstash-1.1.9 package
+
+To create the package, download the jar file from
+`https://logstash.objects.dreamhost.com/release/logstash-1.1.9-monolithic.jar`
+to `/var/tmp/`.
+
+This recipe won't run on Jenkins, run it locally and copy the file to
+the Aptly machine.

--- a/fpm/recipes/logstash/recipe.rb
+++ b/fpm/recipes/logstash/recipe.rb
@@ -1,0 +1,18 @@
+class Logstash < FPM::Cookery::Recipe
+  description 'Logstash'
+
+  name       'logstash'
+  version    '1.1.9'
+  license    'MIT'
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  source     'file:///var/tmp/logstash-1.1.9-monolithic.jar'
+
+  arch     'all'
+
+  def build
+  end
+
+  def install
+    var('tmp').install 'logstash-1.1.9-monolithic.jar'
+  end
+end


### PR DESCRIPTION
Add recipe to package the Logstash jar file. The file is quite big,
so we are not going to include it in this repo. To create the package,
download the jar file from `https://logstash.objects.dreamhost.com/release/logstash-1.1.9-monolithic.jar`
to `/var/tmp/`.

This recipe won't run on Jenkins, run it locally and copy the file to
the Aptly machine.