### PR TITLE
New rubies

### DIFF
--- a/fpm/recipes/ruby-2.2.8/recipe.rb
+++ b/fpm/recipes/ruby-2.2.8/recipe.rb
@@ -1,0 +1,32 @@
+class RbenvRuby231 < FPM::Cookery::Recipe
+
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.2.8'
+  version '1'
+
+  source "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz"
+  sha256 'b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.2.8'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end

--- a/fpm/recipes/ruby-2.3.5/recipe.rb
+++ b/fpm/recipes/ruby-2.3.5/recipe.rb
@@ -1,0 +1,32 @@
+class RbenvRuby231 < FPM::Cookery::Recipe
+
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.3.5'
+  version '1'
+
+  source "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz"
+  sha256 'f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.3.5'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end

--- a/fpm/recipes/ruby-2.4.2/recipe.rb
+++ b/fpm/recipes/ruby-2.4.2/recipe.rb
@@ -1,0 +1,32 @@
+class RbenvRuby240 < FPM::Cookery::Recipe
+
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.4.2'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz'
+  sha256 '08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.4.2'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end


### PR DESCRIPTION
Security patches addressing: 

CVE-2017-0898: Buffer underrun vulnerability in Kernel.sprintf
CVE-2017-10784: Escape sequence injection vulnerability in the Basic authentication of WEBrick
CVE-2017-14033: Buffer underrun vulnerability in OpenSSL ASN1 docode
CVE-2017-14064: Heap exposure vulnerability in generating JSON
Multiple vulnerabilities in RubyGems
Updated bundled libyaml to version 0.1.7

[2.4.2](https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-4-2-released/)
[2.3.5](https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-3-5-released/)
[2.2.8](https://www.ruby-lang.org/en/news/2017/09/14/ruby-2-2-8-released/)