### PR TITLE
Fix Ruby checksums

### DIFF
--- a/fpm/recipes/ruby-2.2.8/recipe.rb
+++ b/fpm/recipes/ruby-2.2.8/recipe.rb
@@ -5,7 +5,7 @@ class RbenvRuby231 < FPM::Cookery::Recipe
   version '1'
 
   source "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.8.tar.gz"
-  sha256 'b19085587d859baf9d7763f92e34a84632fceac5cc593ca2c0efa28ed8c6e44e'
+  sha256 '8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a'
 
   maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
   license 'Ruby'

--- a/fpm/recipes/ruby-2.3.5/recipe.rb
+++ b/fpm/recipes/ruby-2.3.5/recipe.rb
@@ -5,7 +5,7 @@ class RbenvRuby231 < FPM::Cookery::Recipe
   version '1'
 
   source "https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.5.tar.gz"
-  sha256 'f71c4b67ba1bef424feba66774dc9d4bbe02375f5787e41596bc7f923739128b'
+  sha256 '5462f7bbb28beff5da7441968471ed922f964db1abdce82b8860608acc23ddcc'
 
   maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
   license 'Ruby'

--- a/fpm/recipes/ruby-2.4.2/recipe.rb
+++ b/fpm/recipes/ruby-2.4.2/recipe.rb
@@ -5,7 +5,7 @@ class RbenvRuby240 < FPM::Cookery::Recipe
   version '1'
 
   source 'https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.2.tar.gz'
-  sha256 '08e72d0cbe870ed1317493600fbbad5995ea3af2d0166585e7ecc85d04cc50dc'
+  sha256 '93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c'
 
   maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
   license 'Ruby'


### PR DESCRIPTION
The previous PR for these Ruby versions had the `.tar.gz` files but the `.tar.bz2` checksums. Unsurprisingly... that didn't work.