### PR TITLE
Upgrade Terraform to 0.11.1

### DIFF
--- a/fpm/recipes/terraform/recipe.rb
+++ b/fpm/recipes/terraform/recipe.rb
@@ -2,10 +2,10 @@ class Terraform < FPM::Cookery::Recipe
   name 'terraform'
   homepage 'https://www.terraform.io/'
 
-  version '0.9.10'
+  version '0.11.1'
 
   source "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
-  sha256 '77f0d01182d665f7f3c63c326aa699b452fba043c2e2f9050c4bd114f98a1207'
+  sha256 '4e3d5e4c6a267e31e9f95d4c1b00f5a7be5a319698f0370825b459cb786e2f35'
 
   maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
   license 'Mozilla Public License, version 2.0'


### PR DESCRIPTION
We use 0.11.1 for the code when deploying to AWS. Upgrading to this package will enable us to test deploying using Jenkins.