### PR TITLE
Upgrade Terraform to 0.11.2

### DIFF
--- a/fpm/recipes/terraform/recipe.rb
+++ b/fpm/recipes/terraform/recipe.rb
@@ -2,10 +2,10 @@ class Terraform < FPM::Cookery::Recipe
   name 'terraform'
   homepage 'https://www.terraform.io/'
 
-  version '0.11.1'
+  version '0.11.2'
 
   source "https://releases.hashicorp.com/terraform/#{version}/terraform_#{version}_linux_amd64.zip"
-  sha256 '4e3d5e4c6a267e31e9f95d4c1b00f5a7be5a319698f0370825b459cb786e2f35'
+  sha256 'f728fa73ff2a4c4235a28de4019802531758c7c090b6ca4c024d48063ab8537b'
 
   maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
   license 'Mozilla Public License, version 2.0'


### PR DESCRIPTION
This keeps us up to date with the code we're using for GOV.UK AWS.