### PR TITLE
Make binary executable

### DIFF
--- a/fpm/recipes/sops/recipe.rb
+++ b/fpm/recipes/sops/recipe.rb
@@ -15,6 +15,7 @@ class Sops < FPM::Cookery::Recipe
 
   def install
     safesystem "mkdir -p #{destdir}/usr/local/bin/"
+    safesystem "chmod +x #{builddir}/sops-#{version}.linux/*"
     safesystem "cp -f #{builddir}/sops-#{version}.linux/* #{destdir}/usr/local/bin/sops"
   end
 end


### PR DESCRIPTION
It appears when the binary is unpacked it is not executable. Add in a build step to ensure this is the case when it is packaged and installed on a system.

I have done this manually for now, but this should save anyone in the future.