### PR TITLE
Added recipes for a Python installation in /usr/local

### DIFF
--- a/fpm/recipes/gds-local_pip-10.0.1/recipe.rb
+++ b/fpm/recipes/gds-local_pip-10.0.1/recipe.rb
@@ -1,0 +1,26 @@
+class GdsLocalPip1001 < FPM::Cookery::Recipe
+
+  homepage 'https://pip.pypa.io/en/stable/'
+  name 'gds-local_pip'
+  version '10.0.1'
+
+  description 'Pip for self-compiled Python installation to live in /usr/local, necessary due to TLS requirements not fulfilled in 2.7.6 (Trustys own)'
+
+  source 'https://github.com/pypa/pip/archive/10.0.1.zip'
+  sha256 '1812905ce4d87360f63b7bc30444790c8f0be7553aed5516513ada93a85a77b0'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'MIT'
+
+  build_depends 'gds-local_python','gds_local_setuptools'
+
+  depends 'gds-local_python','gds-local_setuptools'
+
+  def build
+    sh "cd pip-10.0.1 && /usr/local/bin/python setup.py build"
+  end
+
+  def install
+    sh "cd pip-10.0.1 && /usr/local/bin/python setup.py install"
+  end
+end

--- a/fpm/recipes/gds-local_python-2.7.14/recipe.rb
+++ b/fpm/recipes/gds-local_python-2.7.14/recipe.rb
@@ -1,0 +1,31 @@
+class GdsLocalPython2714 < FPM::Cookery::Recipe
+
+  homepage 'https://www.python.org/'
+  name 'gds-local_python'
+  version '2.7.14'
+
+  description 'Self-compiled Python installation to live in /usr/local, necessary due to TLS requirements not fulfilled in 2.7.6 (Trustys own)'
+
+  source 'https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz'
+  sha256 '304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Python 2.7 License'
+
+  build_depends 'autoconf', 'build-essential', 'libssl-dev',
+                'libexpat1-dev', 'libncurses5-dev', 'libffi-dev',
+                'multiarch-support'
+
+  depends 'libc6', 'libssl1.0.0', 'mime-support', 'libreadline6', 'zlib1g',
+          'libncursesw5', 'libffi6', 'libsqlite3-0', 'libdb5.3',
+          'libtinfo5'
+
+  def build
+    configure
+    make
+  end
+
+  def install
+    make :install
+  end
+end

--- a/fpm/recipes/gds-local_setuptools-39.0.1/recipe.rb
+++ b/fpm/recipes/gds-local_setuptools-39.0.1/recipe.rb
@@ -1,0 +1,27 @@
+class GdsLocalSetuptools3901 < FPM::Cookery::Recipe
+
+  homepage 'https://pypi.org/project/setuptools/'
+  name 'gds-local_setuptools'
+  version '39.0.1'
+
+  description 'Setuptools for self-compiled Python installation to live in /usr/local, necessary due to TLS requirements not fulfilled in 2.7.6 (Trustys own)'
+
+  source 'https://github.com/pypa/setuptools/archive/v39.0.1.zip'
+  sha256 '25e3b711d035890c9ae8f662fc7e71f31d156fdeb62b824d05e4fe961b6f3284'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'MIT'
+
+  build_depends 'gds-local_python'
+
+  depends 'gds-local_python'
+
+  def build
+    sh "cd setuptools-39.0.1 && /usr/local/bin/python bootstrap.py"
+    sh "cd setuptools-39.0.1 && /usr/local/bin/python setup.py build"
+  end
+
+  def install
+    sh "cd setuptools-39.0.1 && /usr/local/bin/python setup.py install"
+  end
+end


### PR DESCRIPTION
- The lastest Python version in Trusty does not support SSL/TLS as required
  by the fetch search data Jenkins job, thus manually building and adding 2.7.14.

- This has been requested of GOV.UK infra by platform health.

Solo: @schmie