### PR TITLE
Added recipes for a Python installation in /opt

### DIFF
--- a/fpm/recipes/govuk-python-2.7.14/recipe.rb
+++ b/fpm/recipes/govuk-python-2.7.14/recipe.rb
@@ -1,0 +1,33 @@
+class GovukPython2714 < FPM::Cookery::Recipe
+
+  homepage 'https://www.python.org/'
+  name 'govuk-python'
+  version '2.7.14'
+
+  description 'Self-compiled Python installation to live in /opt/python2.7, necessary due to TLS requirements not fulfilled in 2.7.6 (Trustys own)'
+
+  source 'https://www.python.org/ftp/python/2.7.14/Python-2.7.14.tgz'
+  sha256 '304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Python 2.7 License'
+
+  default_prefix '/opt/python2.7'
+
+  build_depends 'autoconf', 'build-essential', 'libssl-dev',
+                'libexpat1-dev', 'libncurses5-dev', 'libffi-dev',
+                'multiarch-support'
+
+  depends 'libc6', 'libssl1.0.0', 'mime-support', 'libreadline6', 'zlib1g',
+          'libncursesw5', 'libffi6', 'libsqlite3-0', 'libdb5.3',
+          'libtinfo5'
+
+  def build
+    configure :prefix => prefix 
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end

--- a/fpm/recipes/govuk-python-pip-10.0.1/recipe.rb
+++ b/fpm/recipes/govuk-python-pip-10.0.1/recipe.rb
@@ -1,0 +1,26 @@
+class GovukPip1001 < FPM::Cookery::Recipe
+
+  homepage 'https://pip.pypa.io/en/stable/'
+  name 'govuk-python-pip'
+  version '10.0.1'
+
+  description 'Pip for self-compiled Python installation to live in /usr/local, necessary due to TLS requirements not fulfilled in 2.7.6 (Trustys own)'
+
+  source 'https://github.com/pypa/pip/archive/10.0.1.zip'
+  sha256 '1812905ce4d87360f63b7bc30444790c8f0be7553aed5516513ada93a85a77b0'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'MIT'
+
+  build_depends 'govuk-python','govuk-python-setuptools'
+
+  depends 'govuk-python','govuk-python-setuptools'
+
+  def build
+    sh "PATH=/opt/python2.7/bin:${PATH} && PYTHONHOME=/opt/python2.7 && PYTHONPATH=/opt/python2.7/lib/python2.7/dist-packages && cd pip-10.0.1 && python setup.py build"
+  end
+
+  def install
+    sh "PATH=/opt/python2.7/bin:${PATH} && PYTHONHOME=/opt/python2.7 && PYTHONPATH=/opt/python2.7/lib/python2.7/dist-packages && cd pip-10.0.1 && python setup.py install --prefix /opt/python2.7 --root #{destdir} --install-lib /opt/python2.7/lib/python2.7/site-packages"
+  end
+end

--- a/fpm/recipes/govuk-python-setuptools-39.0.1/recipe.rb
+++ b/fpm/recipes/govuk-python-setuptools-39.0.1/recipe.rb
@@ -1,0 +1,28 @@
+class GovukSetuptools3901 < FPM::Cookery::Recipe
+
+  homepage 'https://pypi.org/project/setuptools/'
+  name 'govuk-python-setuptools'
+  version '39.0.1'
+
+  description 'Setuptools for self-compiled Python installation to live in /opt, necessary due to TLS requirements not fulfilled in 2.7.6 (Trustys own)'
+
+  source 'https://github.com/pypa/setuptools/archive/v39.0.1.zip'
+  sha256 '25e3b711d035890c9ae8f662fc7e71f31d156fdeb62b824d05e4fe961b6f3284'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'MIT'
+
+  build_depends 'govuk-python'
+
+  depends 'govuk-python'
+
+  def build
+    sh "PATH=/opt/python2.7/bin:${PATH} && PYTHONHOME=/opt/python2.7 && cd setuptools-39.0.1 && python bootstrap.py"
+    sh "PATH=/opt/python2.7/bin:${PATH} && PYTHONHOME=/opt/python2.7 && cd setuptools-39.0.1 && python setup.py build"
+  end
+
+  def install
+   sh "PATH=/opt/python2.7/bin:${PATH} && PYTHONHOME=/opt/python2.7 && cd setuptools-39.0.1 && python setup.py install --prefix /opt/python2.7 --root #{destdir} --install-lib /opt/python2.7/lib/python2.7/site-packages"
+  end
+
+end


### PR DESCRIPTION
- The lastest Python version in Trusty does not support SSL/TLS as required
  by the fetch search data Jenkins job, thus manually building and adding 2.7.14.

- This has been requested of GOV.UK infra by platform health.

Solo: @schmie