### PR TITLE
Build in containers

### DIFF
--- a/fpm/.dockerignore
+++ b/fpm/.dockerignore
@@ -1,0 +1,4 @@
+recipes/*/cache
+recipes/*/tmp-build
+recipes/*/tmp-dest
+

--- a/fpm/Dockerfile.trusty
+++ b/fpm/Dockerfile.trusty
@@ -1,0 +1,16 @@
+FROM ubuntu:trusty
+
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get -y install \
+    curl wget build-essential ruby ruby-dev unzip
+
+COPY Gemfile /tmp
+COPY Gemfile.lock /tmp
+
+RUN gem install bundler \
+  && bundle install --gemfile=/tmp/Gemfile \
+  && rm /tmp/Gemfile /tmp/Gemfile.lock
+
+COPY container-build.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/container-build.sh", "-d", "trusty", "-i"]

--- a/fpm/Dockerfile.xenial
+++ b/fpm/Dockerfile.xenial
@@ -1,0 +1,16 @@
+FROM ubuntu:xenial
+
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get -y install \
+    curl wget build-essential ruby ruby-dev unzip
+
+COPY Gemfile /tmp
+COPY Gemfile.lock /tmp
+
+RUN gem install bundler \
+  && bundle install --gemfile=/tmp/Gemfile \
+  && rm /tmp/Gemfile /tmp/Gemfile.lock
+
+COPY container-build.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/container-build.sh", "-d", "xenial", "-i"]

--- a/fpm/Gemfile
+++ b/fpm/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org/'
 
-gem 'fpm', '1.9.2'
-gem 'fpm-cookery', '0.32.0'
+gem 'fpm'
+gem 'fpm-cookery'

--- a/fpm/Gemfile.lock
+++ b/fpm/Gemfile.lock
@@ -1,20 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.5)
     addressable (2.3.8)
     arr-pm (0.0.10)
       cabin (> 0)
-    backports (3.8.0)
+    backports (3.11.3)
     cabin (0.9.0)
-    childprocess (0.7.1)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
-    dotenv (2.2.1)
-    facter (2.5.0)
-      CFPropertyList (~> 2.2)
-    ffi (1.9.18)
-    fpm (1.9.2)
+    dotenv (2.4.0)
+    facter (2.5.1)
+    ffi (1.9.25)
+    fpm (1.10.0)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
@@ -23,20 +21,23 @@ GEM
       ffi
       json (>= 1.7.7, < 2.0)
       pleaserun (~> 0.0.29)
-      ruby-xz
+      ruby-xz (~> 0.2.3)
       stud
-    fpm-cookery (0.32.0)
+    fpm-cookery (0.33.0)
       addressable (~> 2.3.8)
       facter
       fpm (~> 1.1)
+      json (>= 1.7.7, < 2.0)
+      json_pure (>= 1.7.7, < 2.0)
       puppet (~> 3.4)
+      safe_yaml (~> 1.0.4)
       systemu
     hiera (1.3.4)
       json_pure
     insist (1.0.0)
     io-like (0.3.0)
     json (1.8.6)
-    json_pure (2.1.0)
+    json_pure (1.8.6)
     mustache (0.99.8)
     pleaserun (0.0.30)
       cabin (> 0)
@@ -52,6 +53,7 @@ GEM
     ruby-xz (0.2.3)
       ffi (~> 1.9)
       io-like (~> 0.3)
+    safe_yaml (1.0.4)
     stud (0.0.23)
     systemu (2.6.5)
 
@@ -59,5 +61,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fpm (= 1.9.2)
-  fpm-cookery (= 0.32.0)
+  fpm
+  fpm-cookery
+
+BUNDLED WITH
+   1.16.1

--- a/fpm/container-build.sh
+++ b/fpm/container-build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+supported_distros=(trusty xenial)
+
+usage() {
+  echo "Usage: $0 -d DISTRO -r RECIPE [-x]"
+  echo
+  echo "  Option    Or env. variable   "
+  echo "      -d    DISTRO             One of (${supported_distros[*]})"
+  echo "      -r    RECIPE             Recipe to build"
+  echo "      -x                       Bash \`set -x\` (trace)"
+  exit 0
+}
+
+while getopts "d:r:x:ih" opt
+do
+  case "$opt" in
+    d) DISTRO="$OPTARG" ;;
+    r) RECIPE="$OPTARG" ;;
+    i) in_container=1 ;;
+    x) set -x ;;
+    h) usage ;;
+    *) usage ;;
+  esac
+done
+
+: "${DISTRO?"Not specified (pass -d option or set environment variable)"}"
+: "${RECIPE?"Not specified (pass -r option or set environment variable)"}"
+
+if ! [[ "${supported_distros[*]}" =~ $DISTRO ]]
+then
+  echo "Supported distros: ${supported_distros[*]}"
+  exit 1
+fi
+
+if [[ "$in_container" == 1 ]]
+then
+  cd "/build/${RECIPE}"
+  rm -rf cache tmp-build tmp-dest
+  fpm-cook
+else
+  dockerfile="Dockerfile.$DISTRO"
+  docker build -f "$dockerfile" --tag "alphagov-packager:${DISTRO}" .
+  export DISTRO
+  export RECIPE
+  docker run -it \
+    --mount type=bind,source="$(pwd)/recipes",target=/build \
+    --env RECIPE --env DISTRO \
+    "alphagov-packager:${DISTRO}"
+fi
+


### PR DESCRIPTION
Use Docker to provide consistent repeatable Ubuntu Trusty and Xenial build environments. This works on a recent Docker on macOS and would also work on a Linux build server with Docker installed.