### PR TITLE
Don't quote an empty string in shell script

### DIFF
--- a/fpm/container-build.sh
+++ b/fpm/container-build.sh
@@ -50,7 +50,7 @@ else
   docker_tty=""
   [[ -t 0 ]] && docker_tty="-it"
 
-  docker run "$docker_tty" \
+  docker run $docker_tty \
     --mount type=bind,source="$(pwd)/recipes",target=/build \
     --env RECIPE --env DISTRO \
     "alphagov-packager:${DISTRO}"


### PR DESCRIPTION
Quoting the string seems to pass an empty string as an argument to the command, which breaks things