### PR TITLE
Add recipes for Ruby 2.4.5 and 2.5.3

### DIFF
--- a/fpm/recipes/ruby-2.4.5/recipe.rb
+++ b/fpm/recipes/ruby-2.4.5/recipe.rb
@@ -1,0 +1,32 @@
+class RbenvRuby245 < FPM::Cookery::Recipe
+
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.4.5'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.5.tar.gz'
+  sha256 '6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.4.5'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end

--- a/fpm/recipes/ruby-2.5.3/recipe.rb
+++ b/fpm/recipes/ruby-2.5.3/recipe.rb
@@ -1,0 +1,32 @@
+class RbenvRuby253 < FPM::Cookery::Recipe
+
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.5.3'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.3.tar.gz'
+  sha256 '9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.5.3'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end


### PR DESCRIPTION
This will allow us to run apps using the latest version of Ruby, which solves some security vulnerabilities.

Needed by https://github.com/alphagov/govuk-puppet/pull/8223