### PR TITLE
trello-1899: node-exporter to run on 9080

### DIFF
--- a/fpm/recipes/prometheus-node-exporter-0.17.0/upstart-node-exporter.conf
+++ b/fpm/recipes/prometheus-node-exporter-0.17.0/upstart-node-exporter.conf
@@ -9,4 +9,6 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 
 respawn
 
-exec start-stop-daemon --start --exec /usr/local/bin/node_exporter
+script
+/usr/local/bin/node_exporter --web.listen-address=:9080
+end script


### PR DESCRIPTION
Prometheus node-exporter by default runs on 9100, this is clashing with our
existing rabbitmq port, 9090 is used by garphite, so we are setting our
node-exporter to run on port 9080.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@jstandring-gds <julian.standring@digital.cabinet-office.gov.uk>