### PR TITLE
Trello-1902: Build prometheus server pkg

### DIFF
--- a/fpm/recipes/prometheus/recipe.rb
+++ b/fpm/recipes/prometheus/recipe.rb
@@ -1,0 +1,26 @@
+class Prometheus_server < FPM::Cookery::Recipe
+  name 'prometheus'
+  homepage 'https://prometheus.io'
+
+  version '2.6.0'
+
+  source "https://github.com/prometheus/prometheus/releases/download/v2.6.0/prometheus-2.6.0.linux-amd64.tar.gz"
+  sha256 '8f1f9ca9dbc06e1dc99200e30526ca8343dfe80c2bd950847d22182953261c6c'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'LGPLv3'
+
+  def build
+  end
+
+  def install
+    # create directory for the binary
+    safesystem "mkdir -p #{destdir}/usr/local/bin/"
+    # create directory for holding the prometheus configuration
+    safesystem "mkdir -p #{destdir}/etc/prometheus/"
+    # copy the binary into place
+    safesystem "cp -f #{builddir}/#{name}-#{version}.linux-amd64/#{name} #{destdir}/usr/local/bin/"
+    # drop in the init script
+    etc('init').install workdir('upstart-prometheus.conf'), 'prometheus.conf'
+  end
+end

--- a/fpm/recipes/prometheus/upstart-prometheus.conf
+++ b/fpm/recipes/prometheus/upstart-prometheus.conf
@@ -1,0 +1,14 @@
+# prometheus: Prometheus Server - to collect metrics and observ things
+#
+# Homepage: https://prometheus.io
+#
+
+description "prometheus: Prometheus Server - to collect metrics and observ things"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+
+respawn
+
+script
+/usr/local/bin/prometheus --config.file=/etc/prometheus/prometheus.yml
+end script


### PR DESCRIPTION
This builds the server package for prometheus.
With an upstart script, the prometheus.yml config file will be handled
by puppet when it installs this package.

@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@jstandring-gds <julian.standringn@digital.cabinet-office.gov.uk>