### PR TITLE
Ensure bundler version works with trusty Ruby version

### DIFF
--- a/fpm/Dockerfile.trusty
+++ b/fpm/Dockerfile.trusty
@@ -8,7 +8,7 @@ RUN apt-get update \
 COPY Gemfile /tmp
 COPY Gemfile.lock /tmp
 
-RUN gem install bundler \
+RUN gem install bundler -v "< 2" \
   && bundle install --gemfile=/tmp/Gemfile \
   && rm /tmp/Gemfile /tmp/Gemfile.lock
 


### PR DESCRIPTION
** Context **
The following error happens when running docker build with the
Dockerfile.trusty build file. This could be addressed by changing the OS,
upgrading ruby or downgrading bundler.
```
ERROR:  Error installing bundler:
	bundler requires Ruby version >= 2.3.0.
```

** Decision **
The goal is to get fpm builds working with docker. Changing the OS across the
estate or upgrading ruby for trusty will take considerably more effort than
downgrading the bundler version. So, ensure that bundler is a compatible
version by setting to `-v "< 2"`.