### PR TITLE
Add a recipe for Ruby 2.6.5

### DIFF
--- a/fpm/recipes/ruby-2.6.5/recipe.rb
+++ b/fpm/recipes/ruby-2.6.5/recipe.rb
@@ -1,0 +1,31 @@
+class RbenvRuby265 < FPM::Cookery::Recipe
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.6.5'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.5.tar.gz'
+  sha256 '66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv.
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.6.5'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end


### PR DESCRIPTION
This is based on the 2.6.3 recipe (which was based on the 2.6.2 recipe).

https://trello.com/c/gBa3LyxI/745-ruby-upgrade