### PR TITLE
Adding git to docker build image

### DIFF
--- a/fpm/Dockerfile.trusty
+++ b/fpm/Dockerfile.trusty
@@ -3,7 +3,7 @@ FROM ubuntu:trusty
 RUN apt-get update \
   && apt-get -y upgrade \
   && apt-get -y install \
-    curl wget build-essential ruby ruby-dev unzip
+    curl wget build-essential ruby ruby-dev unzip git
 
 COPY Gemfile /tmp
 COPY Gemfile.lock /tmp

--- a/fpm/Dockerfile.xenial
+++ b/fpm/Dockerfile.xenial
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 RUN apt-get update \
   && apt-get -y upgrade \
   && apt-get -y install \
-    curl wget build-essential ruby ruby-dev unzip
+    curl wget build-essential ruby ruby-dev unzip git
 
 COPY Gemfile /tmp
 COPY Gemfile.lock /tmp


### PR DESCRIPTION
FPM Cookery requires git installed, this installs git
in to the continer.

It allows fpm cookery to clone git repos, configure things,
and inspect git repos.

Pair: @camdesgov & @smford