### PR TITLE
fpm: add solr-6 package

### DIFF
--- a/fpm/recipes/solr-6/init.solr
+++ b/fpm/recipes/solr-6/init.solr
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### BEGIN INIT INFO
+# Provides:          solr
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       Controls Apache Solr as a Service
+### END INIT INFO
+
+# Example of a very simple *nix init script that delegates commands to the bin/solr script
+# Typical usage is to do:
+#
+#   cp bin/init.d/solr /etc/init.d/solr
+#   chmod 755 /etc/init.d/solr
+#   chown root:root /etc/init.d/solr
+#   update-rc.d solr defaults
+#   update-rc.d solr enable
+
+# Where you extracted the Solr distribution bundle
+SOLR_INSTALL_DIR='/opt/solr'
+
+if [ ! -d "$SOLR_INSTALL_DIR" ]; then
+  echo "$SOLR_INSTALL_DIR not found! Please check the SOLR_INSTALL_DIR setting in your $0 script."
+  exit 1
+fi
+
+# Path to an include file that defines environment specific settings to override default
+# variables used by the bin/solr script. It's highly recommended to define this script so
+# that you can keep the Solr binary files separated from live files (pid, logs, index data, etc)
+# see bin/solr.in.sh for an example
+SOLR_ENV="/etc/default/solr.in.sh"
+
+if [ ! -f "$SOLR_ENV" ]; then
+  echo "$SOLR_ENV not found! Please check the SOLR_ENV setting in your $0 script."
+  exit 1
+fi
+
+# Specify the user to run Solr as; if not set, then Solr will run as root.
+# Running Solr as root is not recommended for production environments
+RUNAS='solr'
+
+# verify the specified run as user exists
+runas_uid="`id -u "$RUNAS"`"
+if [ $? -ne 0 ]; then
+  echo "User $RUNAS not found! Please create the $RUNAS user before running this script."
+  exit 1
+fi
+
+case "$1" in
+  start|stop|restart|status)
+    SOLR_CMD="$1"
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit
+esac
+
+if [ -n "$RUNAS" ]; then
+  su -c "SOLR_INCLUDE=\"$SOLR_ENV\" \"$SOLR_INSTALL_DIR/bin/solr\" $SOLR_CMD" - "$RUNAS"
+else
+  SOLR_INCLUDE="$SOLR_ENV" "$SOLR_INSTALL_DIR/bin/solr" "$SOLR_CMD"
+fi

--- a/fpm/recipes/solr-6/post-install
+++ b/fpm/recipes/solr-6/post-install
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+  configure)
+    if ! getent passwd solr > /dev/null; then
+      # user needs a login shell because solr's init script uses `su -` for the user switch
+      adduser --system --group --home /var/lib/solr --shell /bin/sh --quiet solr
+    fi
+
+    if [ ! -e "/var/lib/solr/solr.xml" ] ; then
+      cp /opt/solr/server/solr/solr.xml /var/lib/solr/solr.xml
+    fi
+
+    chown -R solr:solr /var/log/solr /var/lib/solr /var/run/solr
+
+    ;;
+
+  abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac

--- a/fpm/recipes/solr-6/post-uninstall
+++ b/fpm/recipes/solr-6/post-uninstall
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+    remove)
+        # Nothing to do here
+    ;;
+
+    purge)
+        deluser solr || true
+        delgroup solr || true
+    ;;
+
+    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+        # Nothing to do here
+    ;;
+
+    *)
+        echo "$0 called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac

--- a/fpm/recipes/solr-6/recipe.rb
+++ b/fpm/recipes/solr-6/recipe.rb
@@ -1,0 +1,38 @@
+class Solr6 < FPM::Cookery::Recipe
+  homepage    'https://lucene.apache.org/solr/'
+  maintainer  'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+
+  name    'solr'
+  version '6.4.2'
+  revision '1'
+  license 'Apache-2.0'
+
+  source "https://archive.apache.org/dist/lucene/solr/#{version}/solr-#{version}.tgz"
+  sha256 '354e1affd9cad7d6e86cde8c03aaeb604876f0764129621d8e231cdb35b31c55'
+
+  # this *is* a dependency, but provided to the target machines through a 3rd party
+  # repo, and our current build system isn't equipped to handle 3rd party repos
+  #depends 'openjdk-8-jdk'
+
+  post_install   'post-install'
+  post_uninstall 'post-uninstall'
+
+  def build
+  end
+
+  def install
+    install_dir = "#{destdir}/opt/solr"
+    solr_home = "#{destdir}/var/lib/solr"
+    solr_pid_dir = "#{destdir}/var/run/solr"
+    solr_log_dir = "#{destdir}/var/log/solr"
+
+    safesystem "mkdir -p #{install_dir} #{solr_home} #{solr_pid_dir} #{solr_log_dir}"
+    safesystem "cp -r #{builddir}/solr-#{version}/* #{install_dir}"
+
+    # add init script & config file
+    etc('init.d').install workdir('init.solr'), 'solr'
+    etc('default').install workdir('solr.in.sh'), 'solr.in.sh'
+
+    safesystem "chmod 0755 #{destdir}/etc/init.d/solr"
+  end
+end

--- a/fpm/recipes/solr-6/solr.in.sh
+++ b/fpm/recipes/solr-6/solr.in.sh
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Settings here will override settings in existing env vars or in bin/solr.  The default shipped state
+# of this file is completely commented.
+
+# By default the script will use JAVA_HOME to determine which java
+# to use, but you can set a specific path for Solr to use without
+# affecting other Java applications on your server/workstation.
+#SOLR_JAVA_HOME=""
+
+# This controls the number of seconds that the solr script will wait for
+# Solr to stop gracefully or Solr to start.  If the graceful stop fails,
+# the script will forcibly stop Solr.  If the start fails, the script will
+# give up waiting and display the last few lines of the logfile.
+#SOLR_STOP_WAIT="180"
+
+# Increase Java Heap as needed to support your indexing / query needs
+#SOLR_HEAP="512m"
+
+# Expert: If you want finer control over memory options, specify them directly
+# Comment out SOLR_HEAP if you are using this though, that takes precedence
+#SOLR_JAVA_MEM="-Xms512m -Xmx512m"
+
+# Enable verbose GC logging
+#GC_LOG_OPTS="-verbose:gc -XX:+PrintHeapAtGC -XX:+PrintGCDetails \
+#-XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime"
+
+# These GC settings have shown to work well for a number of common Solr workloads
+#GC_TUNE="-XX:NewRatio=3 -XX:SurvivorRatio=4    etc.
+
+# Set the ZooKeeper connection string if using an external ZooKeeper ensemble
+# e.g. host1:2181,host2:2181/chroot
+# Leave empty if not using SolrCloud
+#ZK_HOST=""
+
+# Set the ZooKeeper client timeout (for SolrCloud mode)
+#ZK_CLIENT_TIMEOUT="15000"
+
+# By default the start script uses "localhost"; override the hostname here
+# for production SolrCloud environments to control the hostname exposed to cluster state
+SOLR_HOST='127.0.0.1'
+
+# By default the start script uses UTC; override the timezone if needed
+#SOLR_TIMEZONE="UTC"
+
+# Set to true to activate the JMX RMI connector to allow remote JMX client applications
+# to monitor the JVM hosting Solr; set to "false" to disable that behavior
+# (false is recommended in production environments)
+ENABLE_REMOTE_JMX_OPTS="false"
+
+# The script will use SOLR_PORT+10000 for the RMI_PORT or you can set it here
+# RMI_PORT=18983
+
+# Anything you add to the SOLR_OPTS variable will be included in the java
+# start command line as-is, in ADDITION to other options. If you specify the
+# -a option on start script, those options will be appended as well. Examples:
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.autoSoftCommit.maxTime=3000"
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.autoCommit.maxTime=60000"
+#SOLR_OPTS="$SOLR_OPTS -Dsolr.clustering.enabled=true"
+
+# Location where the bin/solr script will save PID files for running instances
+# If not set, the script will create PID files in $SOLR_TIP/bin
+SOLR_PID_DIR='/var/run/solr'
+
+# Path to a directory for Solr to store cores and their data. By default, Solr will use server/solr
+# If solr.xml is not stored in ZooKeeper, this directory needs to contain solr.xml
+SOLR_HOME='/var/lib/solr'
+
+# Solr provides a default Log4J configuration properties file in server/resources
+# however, you may want to customize the log settings and file appender location
+# so you can point the script to use a different log4j.properties file
+# LOG4J_PROPS='/opt/solr/server/resources/log4j.properties'
+
+# Changes the logging level. Valid values: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF. Default is INFO
+# This is an alternative to changing the rootLogger in log4j.properties
+#SOLR_LOG_LEVEL=INFO
+
+# Location where Solr should write logs to. Absolute or relative to solr start dir
+SOLR_LOGS_DIR='/var/log/solr'
+
+# Sets the port Solr binds to, default is 8983
+SOLR_PORT='8983'
+
+# Uncomment to set SSL-related system properties
+# Be sure to update the paths to the correct keystore for your environment
+#SOLR_SSL_KEY_STORE=/home/shalin/work/oss/shalin-lusolr/solr/server/etc/solr-ssl.keystore.jks
+#SOLR_SSL_KEY_STORE_PASSWORD=secret
+#SOLR_SSL_KEY_STORE_TYPE=JKS
+#SOLR_SSL_TRUST_STORE=/home/shalin/work/oss/shalin-lusolr/solr/server/etc/solr-ssl.keystore.jks
+#SOLR_SSL_TRUST_STORE_PASSWORD=secret
+#SOLR_SSL_TRUST_STORE_TYPE=JKS
+#SOLR_SSL_NEED_CLIENT_AUTH=false
+#SOLR_SSL_WANT_CLIENT_AUTH=false
+
+# Uncomment if you want to override previously defined SSL values for HTTP client
+# otherwise keep them commented and the above values will automatically be set for HTTP clients
+#SOLR_SSL_CLIENT_KEY_STORE=
+#SOLR_SSL_CLIENT_KEY_STORE_PASSWORD=
+#SOLR_SSL_CLIENT_KEY_STORE_TYPE=
+#SOLR_SSL_CLIENT_TRUST_STORE=
+#SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD=
+#SOLR_SSL_CLIENT_TRUST_STORE_TYPE=
+
+# Settings for authentication
+#SOLR_AUTHENTICATION_CLIENT_CONFIGURER=
+#SOLR_AUTHENTICATION_OPTS=
+
+# Settings for ZK ACL
+#SOLR_ZK_CREDS_AND_ACLS="-DzkACLProvider=org.apache.solr.common.cloud.VMParamsAllAndReadonlyDigestZkACLProvider \
+#  -DzkCredentialsProvider=org.apache.solr.common.cloud.VMParamsSingleSetCredentialsDigestZkCredentialsProvider \
+#  -DzkDigestUsername=admin-user -DzkDigestPassword=CHANGEME-ADMIN-PASSWORD \
+#  -DzkDigestReadonlyUsername=readonly-user -DzkDigestReadonlyPassword=CHANGEME-READONLY-PASSWORD"
+#SOLR_OPTS="$SOLR_OPTS $SOLR_ZK_CREDS_AND_ACLS"


### PR DESCRIPTION
Lookie what I did.

https://trello.com/c/zLLNaKtv

A newer solr is going to be needed for CKAN 2.8 and I didn't want to continue the previous use-puppet-as-installer approach. We also are not tied to a fixed, single "core" anymore, which should make CI easier.

Tested on a vanilla trusty installation, appears to work. Default config and init script sourced from solr-6.4.2 release itself, not adding actual java dependency because our current package build system can't provide packages from 3rd party repos. The plan is to use puppet to enforce the dependency rather than redesign our build system.

Why not solr 8? CKAN isn't known to work on anything > 6.5.