### PR TITLE
Add recipe for Ruby 2.7.1

### DIFF
--- a/fpm/recipes/ruby-2.7.1/recipe.rb
+++ b/fpm/recipes/ruby-2.7.1/recipe.rb
@@ -1,0 +1,31 @@
+class RbenvRuby271 < FPM::Cookery::Recipe
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-2.7.1'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz'
+  sha256 'd418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv.
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/2.7.1'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end


### PR DESCRIPTION
Adding recipe for Ruby 2.7.1 so we can upgrade gov uk apps to that version 