### PR TITLE
Add python 3.6.12

### DIFF
--- a/fpm/recipes/govuk-python-3.6.12/recipe.rb
+++ b/fpm/recipes/govuk-python-3.6.12/recipe.rb
@@ -1,0 +1,22 @@
+class Python36 < FPM::Cookery::Recipe
+  homepage 'https://www.python.org/downloads/release/python-3612/'
+  name 'python-3.6.12'
+  
+  source 'https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz'
+  sha256 '12dddbe52385a0f702fb8071e12dcc6b3cb2dde07cd8db3ed60e90d90ab78693'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Python 3.6 License'
+
+  build_depends 'libgeos-dev', 'build-essential', 'libssl-dev',
+                'libffi-dev', 'libpq-dev'
+
+  def build
+    configure :prefix => prefix 
+    make
+  end
+
+  def install
+    make :altinstall, 'DESTDIR' => destdir
+  end
+end


### PR DESCRIPTION
## What

Allows python 3.6.12 to be available on trusty machine, executable installed under `/usr/bin/python3.6`

This is needed for use by CKAN 2.9 which has a minimum of python 3.6 as a requirement.