### PR TITLE
Fix the recipe to be in line with govuk-python 2.7.14

### DIFF
--- a/fpm/recipes/govuk-python-3.6.12/recipe.rb
+++ b/fpm/recipes/govuk-python-3.6.12/recipe.rb
@@ -1,6 +1,7 @@
-class Python36 < FPM::Cookery::Recipe
+class GovukPython3612 < FPM::Cookery::Recipe
   homepage 'https://www.python.org/downloads/release/python-3612/'
-  name 'python-3.6.12'
+  name 'govuk-python'
+  version '3.6.12'
   
   source 'https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz'
   sha256 '12dddbe52385a0f702fb8071e12dcc6b3cb2dde07cd8db3ed60e90d90ab78693'
@@ -9,7 +10,7 @@ class Python36 < FPM::Cookery::Recipe
   license 'Python 3.6 License'
 
   build_depends 'libgeos-dev', 'build-essential', 'libssl-dev',
-                'libffi-dev', 'libpq-dev'
+                'libffi-dev', 'libpq-dev', 'libbz2-dev'
 
   def build
     configure :prefix => prefix 

--- a/fpm/recipes/govuk-python-3.6.12/recipe.rb
+++ b/fpm/recipes/govuk-python-3.6.12/recipe.rb
@@ -3,7 +3,7 @@ class GovukPython3612 < FPM::Cookery::Recipe
   name 'govuk-python'
   version '3.6.12'
   
-  source 'https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz'
+  source "https://www.python.org/ftp/python/#{version}/Python-#{version}.tgz"
   sha256 '12dddbe52385a0f702fb8071e12dcc6b3cb2dde07cd8db3ed60e90d90ab78693'
 
   maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'


### PR DESCRIPTION
## What

Fix the naming to be in line with govuk-python 2.7.14 and also add in `libbz2-dev` needed by libraries like `pandas`, more detail here -

https://stackoverflow.com/questions/51149227/correctly-building-local-python3-with-bz2-support