### PR TITLE
Upgrade prometheus from 2.6.0 to 2.23.0

### DIFF
--- a/fpm/recipes/prometheus/recipe.rb
+++ b/fpm/recipes/prometheus/recipe.rb
@@ -2,10 +2,10 @@ class Prometheus_server < FPM::Cookery::Recipe
   name 'prometheus'
   homepage 'https://prometheus.io'
 
-  version '2.6.0'
+  version '2.23.0'
 
-  source "https://github.com/prometheus/prometheus/releases/download/v2.6.0/prometheus-2.6.0.linux-amd64.tar.gz"
-  sha256 '8f1f9ca9dbc06e1dc99200e30526ca8343dfe80c2bd950847d22182953261c6c'
+  source "https://github.com/prometheus/prometheus/releases/download/v2.23.0/prometheus-2.23.0.linux-amd64.tar.gz"
+  sha256 '0f54cefdb946852947e35d4db8cfce394911ff586486f927c3887db4183cb643'
 
   maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
   license 'LGPLv3'


### PR DESCRIPTION
So, so many new features and enhancements in the last two years...

https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md

In particular, newer versions of prometheus support PromQL subqueries,
which make querying the metrics that router emits much cleaner.

We don't really use our prometheus all that much, so I think this is
fine to just ship-it-and-see.