### PR TITLE
Add fpm recipe for PostGIS 3.1.1

### DIFF
--- a/fpm/recipes/geos-3.9.0/recipe.rb
+++ b/fpm/recipes/geos-3.9.0/recipe.rb
@@ -1,0 +1,18 @@
+class GEOS < FPM::Cookery::Recipe
+  description "GEOS"
+
+  name "geos"
+  version "3.9.0"
+  maintainer "GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>"
+  source "http://download.osgeo.org/geos/geos-#{version}.tar.bz2"
+  sha256 "bd8082cf12f45f27630193c78bdb5a3cba847b81e72b20268356c2a4fc065269"
+
+  def build
+    configure
+    make
+  end
+
+  def install
+    make install: destdir
+  end
+end

--- a/fpm/recipes/postgresql-9.6-postgis-3.1/recipe.rb
+++ b/fpm/recipes/postgresql-9.6-postgis-3.1/recipe.rb
@@ -1,0 +1,22 @@
+class PostGIS < FPM::Cookery::Recipe
+  description "PostGIS"
+
+  name "postgresql-9.6-postgis-3.1.1"
+  version "3.1.1"
+  maintainer "GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>"
+  source "https://download.osgeo.org/postgis/source/postgis-3.1.1.tar.gz"
+  sha256 "0e96afef586db6939d48fb22fbfbc9d0de5e6bc1722d6d553d63bb41441a2a7d"
+
+  chain_package true
+  chain_recipes ["../proj-4.9.3/recipe", "../geos-3.9.0/recipe", "../gdal-2.4.4/recipe"]
+
+  def build
+    safesystem "chmod 0755 #{builddir}/../../geos-3.9.0/tmp-build/geos-3.9.0/tools/geos-config"
+    configure "--with-projdir=#{builddir}/../../proj-4.9.3/tmp-build/proj-4.9.3/src", "--with-gdalconfig=#{builddir}/../../gdal-2.4.4/tmp-build/gdal-2.4.4/apps/gdal-config", "--with-geosconfig=#{builddir}/../../geos-3.9.0/tmp-build/geos-3.9.0/tools/geos-config", "--without-protobuf", "--without-raster"
+    make
+  end
+
+  def install
+    make install: destdir
+  end
+end

--- a/fpm/recipes/proj-4.9.3/recipe.rb
+++ b/fpm/recipes/proj-4.9.3/recipe.rb
@@ -1,0 +1,24 @@
+class PROJ < FPM::Cookery::Recipe
+  description "PROJ"
+
+  name "proj"
+  version "4.9.3"
+  maintainer "GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>"
+  source "https://download.osgeo.org/proj/proj-#{version}.tar.gz"
+  sha256 "6984542fea333488de5c82eea58d699e4aff4b359200a9971537cd7e047185f7"
+
+  chain_package true
+  chain_recipes ["../sqlite-3/recipe"]
+
+  def build
+    ENV["SQLITE3_CFLAGS"] = "#{builddir}/../../sqlite-3/tmp-build/sqlite-autoconf-3340100/"
+    ENV["SQLITE3_LIBS"] = "#{builddir}/../../sqlite-3/tmp-build/sqlite-autoconf-3340100/.libs/"
+    ENV["PATH"] = "#{builddir}/../../sqlite-3/tmp-build/sqlite-autoconf-3340100:#{ENV["PATH"]}"
+    configure "--disable-tiff"
+    make
+  end
+
+  def install
+    make install: destdir
+  end
+end

--- a/fpm/recipes/sqlite-3/recipe.rb
+++ b/fpm/recipes/sqlite-3/recipe.rb
@@ -1,0 +1,18 @@
+class SQLite < FPM::Cookery::Recipe
+  description "SQLite"
+
+  name "sqlite"
+  version "3.34.1"
+  maintainer "GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>"
+  source "https://sqlite.org/2021/sqlite-autoconf-3340100.tar.gz"
+  sha256 "2a3bca581117b3b88e5361d0ef3803ba6d8da604b1c1a47d902ef785c1b53e89"
+
+  def build
+    configure
+    make
+  end
+
+  def install
+    make install: destdir
+  end
+end


### PR DESCRIPTION
This allows us to build a version of PostGIS that is compatible with Ubuntu Trusty, and uses a newer version of GDAL that is supported by Django 3.  Also includes a number of dependencies which are build as part of a chained recipe.

I've run this on a `ci-agent` machine and successfully built the Debian package for Ubuntu Trusty that [has been uploaded to our package server](https://apt.publishing.service.gov.uk/postgis/dists/trusty/main/binary-amd64/Packages).

Trello card: https://trello.com/c/BE3TN7De