### PR TITLE
Fix GDAL 2.4.4 build

### DIFF
--- a/fpm/recipes/gdal-2.4.4/recipe.rb
+++ b/fpm/recipes/gdal-2.4.4/recipe.rb
@@ -10,11 +10,11 @@ class GDAL < FPM::Cookery::Recipe
   sha256 "e6a2456907610639d73fc6a82bb10aa6fa02e2d03b24edacde34a16b6aa91080"
 
   def build
-    configure
+    configure :prefix => prefix
     make
   end
 
   def install
-    make install: destdir
+    make :install, 'DESTDIR' => destdir
   end
 end


### PR DESCRIPTION
It appears the syntax for fpm-cook has changed slightly, so updating to use the latest syntax.

Previously we built an almost empty Debian package containing only a CHANGELOG file. This change allows us to build the full package.

Trello card: https://trello.com/c/BE3TN7De