### PR TITLE
Fix PostGIS 3.1.1 build

### DIFF
--- a/fpm/recipes/geos-3.9.0/recipe.rb
+++ b/fpm/recipes/geos-3.9.0/recipe.rb
@@ -8,11 +8,11 @@ class GEOS < FPM::Cookery::Recipe
   sha256 "bd8082cf12f45f27630193c78bdb5a3cba847b81e72b20268356c2a4fc065269"
 
   def build
-    configure
+    configure :prefix => prefix
     make
   end
 
   def install
-    make install: destdir
+    make :install, 'DESTDIR' => destdir
   end
 end

--- a/fpm/recipes/postgresql-9.6-postgis-3.1/recipe.rb
+++ b/fpm/recipes/postgresql-9.6-postgis-3.1/recipe.rb
@@ -11,12 +11,11 @@ class PostGIS < FPM::Cookery::Recipe
   chain_recipes ["../proj-4.9.3/recipe", "../geos-3.9.0/recipe", "../gdal-2.4.4/recipe"]
 
   def build
-    safesystem "chmod 0755 #{builddir}/../../geos-3.9.0/tmp-build/geos-3.9.0/tools/geos-config"
-    configure "--with-projdir=#{builddir}/../../proj-4.9.3/tmp-build/proj-4.9.3/src", "--with-gdalconfig=#{builddir}/../../gdal-2.4.4/tmp-build/gdal-2.4.4/apps/gdal-config", "--with-geosconfig=#{builddir}/../../geos-3.9.0/tmp-build/geos-3.9.0/tools/geos-config", "--without-protobuf", "--without-raster"
+    configure "--with-projdir=#{builddir}/../../proj-4.9.3/tmp-dest/usr/lib/", "--with-gdalconfig=#{builddir}/../../gdal-2.4.4/tmp-dest/usr/bin/gdal-config", "--with-geosconfig=#{builddir}/../../geos-3.9.0/tmp-dest/usr/bin/geos-config", "--without-protobuf", "--without-raster", :prefix => prefix
     make
   end
 
   def install
-    make install: destdir
+    make :install, 'DESTDIR' => destdir
   end
 end

--- a/fpm/recipes/proj-4.9.3/recipe.rb
+++ b/fpm/recipes/proj-4.9.3/recipe.rb
@@ -14,11 +14,11 @@ class PROJ < FPM::Cookery::Recipe
     ENV["SQLITE3_CFLAGS"] = "#{builddir}/../../sqlite-3/tmp-build/sqlite-autoconf-3340100/"
     ENV["SQLITE3_LIBS"] = "#{builddir}/../../sqlite-3/tmp-build/sqlite-autoconf-3340100/.libs/"
     ENV["PATH"] = "#{builddir}/../../sqlite-3/tmp-build/sqlite-autoconf-3340100:#{ENV["PATH"]}"
-    configure "--disable-tiff"
+    configure "--disable-tiff", :prefix => prefix
     make
   end
 
   def install
-    make install: destdir
+    make :install, 'DESTDIR' => destdir
   end
 end

--- a/fpm/recipes/sqlite-3/recipe.rb
+++ b/fpm/recipes/sqlite-3/recipe.rb
@@ -8,11 +8,11 @@ class SQLite < FPM::Cookery::Recipe
   sha256 "2a3bca581117b3b88e5361d0ef3803ba6d8da604b1c1a47d902ef785c1b53e89"
 
   def build
-    configure
+    configure :prefix => prefix
     make
   end
 
   def install
-    make install: destdir
+    make :install, 'DESTDIR' => destdir
   end
 end


### PR DESCRIPTION
It appears the syntax for fpm-cook has changed slightly, so updating to use the latest syntax.

Previously we built an almost empty Debian package containing only a CHANGELOG file. This change allows us to build the full package.

I've deposited the built Debian package into [our Apt server](https://apt.publishing.service.gov.uk/postgis/dists/trusty/main/binary-amd64/Packages) which shows a considerably larger size than the previous <1kb file :see_no_evil:.

Trello card: https://trello.com/c/BE3TN7De