### PR TITLE
Document how to test a created package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,34 @@ by hand.
 ## legacy-debuild
 
 This is how we used to do things.
+
+## test-your-package
+
+Used for testing your created package. Relies on Docker.
+
+Set up:
+
+```
+$ cd test-your-package
+$ docker build -t trusty .
+```
+
+Check your setup is working:
+
+```
+$ docker run -v ~/Downloads:/home -w /home trusty ls
+# should see your downloaded package in the output
+```
+
+Verify that your package can be imported:
+
+```
+$ docker run -v ~/Downloads:/home -w /home trusty sudo dpkg -i ./rbenv-ruby-2.6.9_1_amd64.deb
+Selecting previously unselected package rbenv-ruby-2.6.9.
+(Reading database ... 19423 files and directories currently installed.)
+Preparing to unpack ./rbenv-ruby-2.6.9_1_amd64.deb ...
+Unpacking rbenv-ruby-2.6.9 (1) ...
+Setting up rbenv-ruby-2.6.9 (1) ...
+```
+
+If there are no errors, your package is good to go.

--- a/test-your-package/Dockerfile
+++ b/test-your-package/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:trusty
+
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get -y install \
+    curl wget build-essential rbenv ruby ruby-dev unzip git


### PR DESCRIPTION
The developer VM has gone away, but the instructions we have for
testing whether a generated package works, relies on the dev VM:
https://github.com/alphagov/govuk-developer-docs/blob/17deefd6068ff955d14c8dbe641d5b5a0dbe66fa/source/manual/debian-packaging.html.md?plain=1#L136-L150

I've found an equivalent way of testing that the package works,
using Docker, which is the technology we've moved onto.

Trello: https://trello.com/c/ZMrLumn8/2837-upgrade-ruby-for-our-apps-5