### PR TITLE
Invalidate DST_Root_CA_X3 CA cert when using trusty image

### DIFF
--- a/fpm/Dockerfile.trusty
+++ b/fpm/Dockerfile.trusty
@@ -5,6 +5,9 @@ RUN apt-get update \
   && apt-get -y install \
     curl wget build-essential ruby ruby-dev unzip git
 
+RUN sed -i '/^mozilla\/DST_Root_CA_X3\.crt/ s/./\!&/' /etc/ca-certificates.conf
+RUN update-ca-certificates
+
 COPY Gemfile /tmp
 COPY Gemfile.lock /tmp
 


### PR DESCRIPTION
As per https://ubuntu.com/security/notices/USN-5089-2
We invalidate this expired CA.
The proper way to do this would be to update the ca-certificates
package. However trusty is not supported anymore and this update
would have to be done through an authenticated ESM repo.
We therefore do this manually in order to minimize the efforts
required.