### PR TITLE
Copy openssl files to destination for python 3.7

### DIFF
--- a/fpm/recipes/govuk-python-3.7.15/recipe.rb
+++ b/fpm/recipes/govuk-python-3.7.15/recipe.rb
@@ -35,6 +35,9 @@ class GovukPython3715 < FPM::Cookery::Recipe
   end
 
   def install
+    safesystem "mkdir -p #{destdir}/openssl/"
+    safesystem "cp -r #{builddir}/Python-3.7.15/openssl-1.1.1g/* #{destdir}/openssl/"
+
     make :altinstall, 'DESTDIR' => destdir
   end
 end


### PR DESCRIPTION
## What 

Fix openssl installation for python3.7 deployment.

## Reference 

https://trello.com/c/ouCltnih/1595-handle-ckan-user-security-vulnerability