### PR TITLE
Add recipes for the latest ruby versions

### DIFF
--- a/fpm/recipes/ruby-3.0.5/recipe.rb
+++ b/fpm/recipes/ruby-3.0.5/recipe.rb
@@ -1,0 +1,31 @@
+class RbenvRuby305 < FPM::Cookery::Recipe
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-3.0.5'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz'
+  sha256 '9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv.
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/3.0.5'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end

--- a/fpm/recipes/ruby-3.1.3/recipe.rb
+++ b/fpm/recipes/ruby-3.1.3/recipe.rb
@@ -1,0 +1,31 @@
+class RbenvRuby313 < FPM::Cookery::Recipe
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-3.1.3'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.tar.gz'
+  sha256 '5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv.
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/3.1.3'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end

--- a/fpm/recipes/ruby-3.2.0/recipe.rb
+++ b/fpm/recipes/ruby-3.2.0/recipe.rb
@@ -1,0 +1,31 @@
+class RbenvRuby320 < FPM::Cookery::Recipe
+  homepage 'https://www.ruby-lang.org/'
+  name 'rbenv-ruby-3.2.0'
+  version '1'
+
+  source 'https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.tar.gz'
+  sha256 'daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272'
+
+  maintainer 'GOV.UK <govuk-dev@digital.cabinet-office.gov.uk>'
+  license 'Ruby'
+
+  build_depends 'autoconf', 'bison', 'build-essential', 'libssl-dev',
+                'libyaml-dev', 'libreadline6-dev', 'zlib1g-dev',
+                'libncurses5-dev', 'libffi-dev', 'libgdbm3', 'libgdbm-dev'
+
+  depends 'rbenv', 'libssl1.0.0', 'libyaml-0-2', 'libreadline6', 'zlib1g',
+          'libncurses5', 'libffi6', 'libgdbm3', 'libtinfo5'
+
+  section 'interpreters'
+  description 'Ruby version for use with rbenv.
+Specific version of Ruby for use with a system install of rbenv.'
+
+  def build
+    configure prefix: '/usr/lib/rbenv/versions/3.2.0'
+    make
+  end
+
+  def install
+    make :install, 'DESTDIR' => destdir
+  end
+end


### PR DESCRIPTION
We need to upgrade the Ruby packages available to GOV.UK. We should install the [latest patch versions available](https://www.ruby-lang.org/en/downloads/releases/).

Trello card: https://trello.com/c/J4lMTZYC/3070-install-ruby-version-320-5